### PR TITLE
Feat/10 slack get - 조회, 키워드 검색

### DIFF
--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationSearchCondition.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationSearchCondition.java
@@ -1,0 +1,11 @@
+package com.team.notificationservice.application;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NotificationSearchCondition {
+    private String slackId;
+    private String keyword; // 메시지 내용 검색용 키워드 추가
+}

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -4,8 +4,11 @@ import com.team.notificationservice.domain.Notification;
 import com.team.notificationservice.domain.NotificationRepository;
 import com.team.notificationservice.domain.SendStatus;
 import com.team.notificationservice.infrastructure.SlackClient;
+import com.team.notificationservice.presentation.NotificationResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,5 +52,19 @@ public class NotificationService {
         } else {
             notification.markAsFailed();
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NotificationResponse> searchNotifications(NotificationSearchCondition condition, Pageable pageable) {
+        // 키워드가 있으면 포함 검색, 없으면 기존대로 전체 조회
+        if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
+            return notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
+                            condition.getSlackId(), condition.getKeyword(), pageable)
+                    .map(NotificationResponse::from);
+        }
+
+        return notificationRepository.findByReceiverSlackIdAndDeletedAtIsNull(
+                        condition.getSlackId(), pageable)
+                .map(NotificationResponse::from);
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -5,6 +5,7 @@ import com.team.notificationservice.domain.NotificationRepository;
 import com.team.notificationservice.domain.SendStatus;
 import com.team.notificationservice.infrastructure.SlackClient;
 import com.team.notificationservice.presentation.NotificationResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -66,5 +67,12 @@ public class NotificationService {
         return notificationRepository.findByReceiverSlackIdAndDeletedAtIsNull(
                         condition.getSlackId(), pageable)
                 .map(NotificationResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationResponse getNotification(UUID id) {
+        return notificationRepository.findByIdAndDeletedAtIsNull(id)
+                .map(NotificationResponse::from)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 삭제된 알림입니다."));
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/domain/NotificationRepository.java
+++ b/notification-service/src/main/java/com/team/notificationservice/domain/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.team.notificationservice.domain;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +12,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
     Page<Notification> findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
             String slackId, String msgContent, Pageable pageable);
+
+    Optional<Notification> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/notification-service/src/main/java/com/team/notificationservice/domain/NotificationRepository.java
+++ b/notification-service/src/main/java/com/team/notificationservice/domain/NotificationRepository.java
@@ -1,7 +1,14 @@
 package com.team.notificationservice.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+    Page<Notification> findByReceiverSlackIdAndDeletedAtIsNull(String slackId, Pageable pageable);
+
+    Page<Notification> findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
+            String slackId, String msgContent, Pageable pageable);
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -1,10 +1,16 @@
 package com.team.notificationservice.presentation;
 
 import com.team.notificationservice.application.NotificationRequest;
+import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,5 +29,13 @@ public class NotificationController {
         log.info("알림 서비스 요청 수신: {}", request); // 요청이 들어오는지 확인
         notificationService.createAndSend(request);
         return ResponseEntity.ok("OK");
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<NotificationResponse>> getNotifications(
+            NotificationSearchCondition condition,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ResponseEntity.ok(notificationService.searchNotifications(condition, pageable));
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -3,6 +3,7 @@ package com.team.notificationservice.presentation;
 import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +39,11 @@ public class NotificationController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return ResponseEntity.ok(notificationService.searchNotifications(condition, pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<NotificationResponse> getNotification(@PathVariable UUID id) {
+        NotificationResponse response = notificationService.getNotification(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationResponse.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationResponse.java
@@ -1,0 +1,26 @@
+package com.team.notificationservice.presentation;
+
+import com.team.notificationservice.domain.Notification;
+import com.team.notificationservice.domain.SendStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationResponse {
+    private UUID id;
+    private String message;
+    private SendStatus status;
+    private LocalDateTime createdAt;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .message(notification.getMsgContent())
+                .status(notification.getSendStatus())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
@@ -1,5 +1,8 @@
 package com.team.notificationservice;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
@@ -7,14 +10,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.team.notificationservice.application.NotificationRequest;
+import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
 import com.team.notificationservice.domain.MsgType;
+import com.team.notificationservice.domain.Notification;
+import com.team.notificationservice.domain.NotificationRepository;
+import com.team.notificationservice.domain.SendStatus;
 import com.team.notificationservice.infrastructure.SlackClient;
+import com.team.notificationservice.presentation.NotificationResponse;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
@@ -22,6 +35,8 @@ class NotificationServiceApplicationTests {
 
     @Autowired
     private NotificationService notificationService;
+    @MockitoBean
+    private NotificationRepository notificationRepository;
 
     @MockitoBean// 실제 슬랙 API 서버를 호출하지 않도록 가짜 객체(Mock) 등록
     private SlackClient slackClient;
@@ -66,5 +81,36 @@ class NotificationServiceApplicationTests {
         // then: 1. 이메일 조회가 발생했는지 확인, 2. 조회된 ID로 발송되었는지 확인
         verify(slackClient, times(1)).findSlackIdByEmail("test@example.com");
         verify(slackClient, times(1)).sendDirectMessage(eq("U_SEARCHED_ID"), anyString());
+    }
+
+    @Test
+    @DisplayName("슬랙 ID와 키워드로 검색 시 검색 결과가 반환되는지 확인")
+    void searchNotificationsMockTest() {
+        // given
+        String slackId = "U12345678";
+        String keyword = "배송";
+
+        // 1. 가짜 결과 데이터 생성
+        Notification mockNotification = Notification.builder()
+                .msgContent("배송이 시작되었습니다.")
+                .receiverSlackId(slackId)
+                .sendStatus(SendStatus.SUCCESS)
+                .build();
+        Page<Notification> mockPage = new PageImpl<>(List.of(mockNotification));
+
+        // 2. 레포지토리가 이 데이터를 주도록 Mock 설정
+        when(notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
+                anyString(), anyString(), any(Pageable.class)))
+                .thenReturn(mockPage);
+
+        // when
+        NotificationSearchCondition condition = new NotificationSearchCondition();
+        condition.setSlackId(slackId);
+        condition.setKeyword(keyword);
+        Page<NotificationResponse> result = notificationService.searchNotifications(condition, PageRequest.of(0, 10));
+
+        // then
+        assertEquals(1, result.getContent().size());
+        assertTrue(result.getContent().get(0).getMessage().contains(keyword));
     }
 }

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
@@ -1,6 +1,7 @@
 package com.team.notificationservice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -19,6 +20,7 @@ import com.team.notificationservice.domain.SendStatus;
 import com.team.notificationservice.infrastructure.SlackClient;
 import com.team.notificationservice.presentation.NotificationResponse;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -112,5 +114,29 @@ class NotificationServiceApplicationTests {
         // then
         assertEquals(1, result.getContent().size());
         assertTrue(result.getContent().get(0).getMessage().contains(keyword));
+    }
+
+    @Test
+    @DisplayName("알림 ID로 단건 조회를 수행한다")
+    void getNotificationTest() {
+        // given
+        UUID notificationId = UUID.randomUUID();
+        Notification mockNotification = Notification.builder()
+                .msgContent("단건 조회 테스트 메시지")
+                .receiverSlackId("U12345678")
+                .sendStatus(SendStatus.SUCCESS)
+                .build();
+
+        // 레포지토리 Mock 설정
+        when(notificationRepository.findByIdAndDeletedAtIsNull(notificationId))
+                .thenReturn(Optional.of(mockNotification));
+
+        // when
+        NotificationResponse response = notificationService.getNotification(notificationId);
+
+        // then
+        assertNotNull(response);
+        assertEquals("단건 조회 테스트 메시지", response.getMessage());
+        assertEquals(SendStatus.SUCCESS, response.getStatus());
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
## 알림에서의 페이징 기반의 조회(전체 & 단건) 및 키워드 검색 기능 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #10 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="552" height="179" alt="스크린샷 2026-03-30 오전 4 05 33" src="https://github.com/user-attachments/assets/47b52a47-6f8a-466c-a333-471c2a9a4aa0" />
<img width="899" height="760" alt="스크린샷 2026-03-30 오전 4 08 38" src="https://github.com/user-attachments/assets/00063758-d24b-43f8-af77-bec46f70c91d" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
- 검색 조건 확장: 현재는 슬랙 ID와 메시지 내용 키워드 검색만 지원하며, 향후 `NotificationSearchCondition`을 통해 검색 조건을 쉽게 확장할 수 있도록 설계했습니다.
- 테스트 전략: 실제 DB 의존성을 제거하기 위해 Repository를 Mock 처리했습니다. 인프라 장애와 무관하게 비즈니스 로직 검증이 가능합니다.
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.
