### PR TITLE
Refactor/42 noti record error restdocs - 알림 DTO record 변경, 에러처리, RestDocs

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -49,3 +49,6 @@ dependencyManagement {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+// IntelliJ Kotlin 플러그인 오류 해결을 위한 태스크 등록
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -35,3 +35,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 }
+
+// IntelliJ Kotlin 플러그인 오류 해결을 위한 태스크 등록
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/company-service/build.gradle
+++ b/company-service/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.13'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.13'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.team'
@@ -9,60 +9,63 @@ version = '0.0.1-SNAPSHOT'
 description = 'company-service'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2025.0.1")
+    set('springCloudVersion', "2025.0.1")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.retry:spring-retry'
 
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-database-postgresql'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-database-postgresql'
 
-	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
+
+// IntelliJ Kotlin 플러그인 오류 해결을 위한 태스크 등록
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.13'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.13'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.team'
@@ -9,23 +9,23 @@ version = '0.0.1-SNAPSHOT'
 description = 'delivery-service'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2025.0.1")
+    set('springCloudVersion', "2025.0.1")
 }
 
 dependencies {
@@ -60,11 +60,14 @@ dependencies {
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
+
+// IntelliJ Kotlin 플러그인 오류 해결을 위한 태스크 등록
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -51,3 +51,6 @@ dependencyManagement {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+// IntelliJ Kotlin 플러그인 오류 해결을 위한 태스크 등록
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -76,3 +76,6 @@ bootJar {
         into 'static/docs'
     }
 }
+
+// IntelliJ Kotlin 플러그인 오류 해결을 위한 태스크 등록
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 dependencyManagement {

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.team'
@@ -17,6 +18,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -25,6 +27,7 @@ repositories {
 
 ext {
     set('springCloudVersion', "2025.0.1")
+    snippetsDir = file('build/generated-snippets')
 }
 
 dependencies {
@@ -42,6 +45,9 @@ dependencies {
     implementation 'com.slack.api:slack-api-client:1.38.0' //슬랙
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
+
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 dependencyManagement {
@@ -50,6 +56,21 @@ dependencyManagement {
     }
 }
 
-tasks.named('test') {
+test {
+    outputs.dir snippetsDir
     useJUnitPlatform()
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt' // 위에서 선언한 asciidoctorExt 사용
+    dependsOn test
+}
+
+// 빌드 시 문서를 포함시키는 설정 (Packaging)
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }

--- a/notification-service/src/docs/asciidoc/index.adoc
+++ b/notification-service/src/docs/asciidoc/index.adoc
@@ -1,0 +1,26 @@
+= Notification Service API Guide
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[Introduction]]
+== 소개
+Notification 서비스의 API 명세서입니다. 모든 응답은 `ApiResponse` 규격을 따릅니다.
+
+[[Notification-API]]
+== 알림(Notification) API
+
+=== 알림 생성 및 슬랙 전송
+operation::notifications/create[snippets='http-request,request-fields,http-response,response-fields']
+
+=== 알림 목록 조회 (검색 포함)
+operation::notifications/list[snippets='http-request,query-parameters,http-response,response-fields']
+
+=== 알림 단건 조회
+operation::notifications/get[snippets='http-request,path-parameters,http-response,response-fields']
+
+=== 알림 삭제
+operation::notifications/delete[snippets='http-request,path-parameters,http-response']

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationCreatedEvent.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.team.notificationservice.application;
+
+import java.util.UUID;
+
+public record NotificationCreatedEvent(
+    UUID notificationId,
+    String receiverSlackId,
+    String message
+) {
+}

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationEventListener.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationEventListener.java
@@ -1,0 +1,66 @@
+package com.team.notificationservice.application;
+
+import com.team.notificationservice.domain.Notification;
+import com.team.notificationservice.domain.NotificationRepository;
+import com.team.notificationservice.infrastructure.SlackClient;
+import com.team.notificationservice.presentation.common.ErrorCode;
+import com.team.notificationservice.presentation.common.ServiceException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final SlackClient slackClient;
+    private final NotificationRepository notificationRepository;
+    // private final KafkaTemplate<String, NotificationCreatedEvent> kafkaTemplate; // TODO: Kafka 도입 시 주입 예정
+
+    /**
+     * 알림 생성 이벤트를 처리 TransactionPhase.AFTER_COMMIT: 메인 비즈니스 로직이 DB에 완전히 커밋된 후 실행됨
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW) // 별도의 트랜잭션에서 전송 결과(성공/실패)를 기록함
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNotificationCreatedEvent(NotificationCreatedEvent event) {
+        log.info("이벤트 수신 - 알림 전송 시작: ID={}", event.notificationId());
+
+        /*
+         * [미래의 Kafka/RabbitMQ 전환 가이드]
+         * ---------------------------------------------------------------------------
+         * 1. 아래의 slackClient 호출 로직을 제거
+         * 2. kafkaTemplate.send("notification-topic", event); 를 호출하여 메시지 브로커로 전달
+         * 3. 별도의 'Consumer' 서비스에서 이 메시지를 받아 실제 슬랙 전송을 처리하게 됨
+         * ---------------------------------------------------------------------------
+         */
+
+        try {
+            // 1. 외부 서비스(슬랙) 호출
+            boolean success = slackClient.sendDirectMessage(event.receiverSlackId(), event.message());
+
+            // 2. 알림 엔티티 조회 (커밋된 이후이므로 findById로 조회가 가능)
+            Notification notification = notificationRepository.findById(event.notificationId())
+                .orElseThrow(() -> new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
+
+            if (success) {
+                notification.markAsSuccess();
+                log.info("슬랙 전송 성공: notificationId={}", event.notificationId());
+            } else {
+                notification.markAsFailed();
+                log.warn("슬랙 전송 실패(API 응답 False): notificationId={}", event.notificationId());
+            }
+        } catch (Exception e) {
+            log.error("슬랙 전송 중 예외 발생: {}", e.getMessage());
+            // 예외 발생 시에도 전송 실패 상태를 DB에 남기기 위해 다시 조회하여 마킹
+            notificationRepository.findById(event.notificationId())
+                .ifPresent(Notification::markAsFailed);
+
+            throw new ServiceException(ErrorCode.NOTI_SLACK_API_ERROR);
+        }
+    }
+}

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationEventListener.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationEventListener.java
@@ -1,10 +1,7 @@
 package com.team.notificationservice.application;
 
-import com.team.notificationservice.domain.Notification;
 import com.team.notificationservice.domain.NotificationRepository;
 import com.team.notificationservice.infrastructure.SlackClient;
-import com.team.notificationservice.presentation.common.ErrorCode;
-import com.team.notificationservice.presentation.common.ServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -22,9 +19,7 @@ public class NotificationEventListener {
     private final NotificationRepository notificationRepository;
     // private final KafkaTemplate<String, NotificationCreatedEvent> kafkaTemplate; // TODO: Kafka 도입 시 주입 예정
 
-    /**
-     * 알림 생성 이벤트를 처리 TransactionPhase.AFTER_COMMIT: 메인 비즈니스 로직이 DB에 완전히 커밋된 후 실행됨
-     */
+    // 알림 생성 이벤트를 처리 TransactionPhase.AFTER_COMMIT: 메인 비즈니스 로직이 DB에 완전히 커밋된 후 실행됨
     @Transactional(propagation = Propagation.REQUIRES_NEW) // 별도의 트랜잭션에서 전송 결과(성공/실패)를 기록함
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleNotificationCreatedEvent(NotificationCreatedEvent event) {
@@ -43,24 +38,26 @@ public class NotificationEventListener {
             // 1. 외부 서비스(슬랙) 호출
             boolean success = slackClient.sendDirectMessage(event.receiverSlackId(), event.message());
 
-            // 2. 알림 엔티티 조회 (커밋된 이후이므로 findById로 조회가 가능)
-            Notification notification = notificationRepository.findById(event.notificationId())
-                .orElseThrow(() -> new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
+            // 2. 알림 엔티티 조회 및 상태 업데이트
+            notificationRepository.findById(event.notificationId()).ifPresentOrElse(notification -> {
+                if (success) {
+                    notification.markAsSuccess();
+                    log.info("슬랙 전송 성공: notificationId={}", event.notificationId());
+                } else {
+                    notification.markAsFailed();
+                    log.warn("슬랙 전송 실패(응답 False): notificationId={}", event.notificationId());
+                }
+                notificationRepository.save(notification); // 변경 사항 명시적 저장
+            }, () -> log.error("알림 엔티티를 찾을 수 없습니다: ID={}", event.notificationId()));
 
-            if (success) {
-                notification.markAsSuccess();
-                log.info("슬랙 전송 성공: notificationId={}", event.notificationId());
-            } else {
-                notification.markAsFailed();
-                log.warn("슬랙 전송 실패(API 응답 False): notificationId={}", event.notificationId());
-            }
         } catch (Exception e) {
             log.error("슬랙 전송 중 예외 발생: {}", e.getMessage());
-            // 예외 발생 시에도 전송 실패 상태를 DB에 남기기 위해 다시 조회하여 마킹
-            notificationRepository.findById(event.notificationId())
-                .ifPresent(Notification::markAsFailed);
-
-            throw new ServiceException(ErrorCode.NOTI_SLACK_API_ERROR);
+            // 예외 발생 시에도 실패 상태를 기록
+            notificationRepository.findById(event.notificationId()).ifPresent(n -> {
+                n.markAsFailed();
+                notificationRepository.save(n);
+            });
+            // AFTER_COMMIT 리스너이므로 사용자 응답에 영향을 주지 않기 위해 예외를 밖으로 던지지 않음
         }
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationRequest.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationRequest.java
@@ -2,17 +2,12 @@ package com.team.notificationservice.application;
 
 import com.team.notificationservice.domain.MsgType;
 import java.util.UUID;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
-public class NotificationRequest {
-    private String receiverSlackId;
-    private String email;
-    private UUID orderId;
-    private String message;
-    private MsgType msgType;
+public record NotificationRequest(
+    String receiverSlackId,
+    String email,
+    UUID orderId,
+    String message,
+    MsgType msgType
+) {
 }

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationRequest.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationRequest.java
@@ -1,6 +1,7 @@
 package com.team.notificationservice.application;
 
 import com.team.notificationservice.domain.MsgType;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -16,4 +17,9 @@ public record NotificationRequest(
     @NotNull(message = "메시지 타입은 필수입니다.")
     MsgType msgType
 ) {
+    @AssertTrue(message = "수신자의 슬랙 ID 또는 이메일 중 하나는 입력되어야 합니다.")
+    public boolean isValidRecipient() {
+        return (receiverSlackId != null && !receiverSlackId.isBlank())
+            || (email != null && !email.isBlank());
+    }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationRequest.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationRequest.java
@@ -1,13 +1,19 @@
 package com.team.notificationservice.application;
 
 import com.team.notificationservice.domain.MsgType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record NotificationRequest(
     String receiverSlackId,
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     String email,
     UUID orderId,
+    @NotBlank(message = "메시지 내용은 필수입니다.")
     String message,
+    @NotNull(message = "메시지 타입은 필수입니다.")
     MsgType msgType
 ) {
 }

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationSearchCondition.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationSearchCondition.java
@@ -1,11 +1,7 @@
 package com.team.notificationservice.application;
 
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
-public class NotificationSearchCondition {
-    private String slackId;
-    private String keyword; // 메시지 내용 검색용 키워드 추가
+public record NotificationSearchCondition(
+    String slackId,
+    String keyword
+) {
 }

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationSearchCondition.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationSearchCondition.java
@@ -1,6 +1,9 @@
 package com.team.notificationservice.application;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record NotificationSearchCondition(
+    @NotBlank(message = "조회할 슬랙 ID는 필수입니다.")
     String slackId,
     String keyword
 ) {

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -71,11 +71,13 @@ public class NotificationService {
                 condition.slackId(), pageable);
         }
 
-        // 결과가 비어있으면 404 예외 발생
-        if (result.isEmpty()) {
-            throw new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND);
-        }
+//        // 결과가 비어있으면 404 예외 발생
+//        if (result.isEmpty()) {
+//            throw new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND);
+//        }
+//        return result.map(NotificationResponse::from);
 
+        // 결과가 비어있어도 404를 던지지 않고 빈 페이지 반환 (200 OK 일관성 유지)
         return result.map(NotificationResponse::from);
     }
 
@@ -94,5 +96,7 @@ public class NotificationService {
 
         // 엔티티에 삭제 처리를 위임
         notification.delete(deletedBy);
+
+        notificationRepository.save(notification); // 변경 사항 명시적 반영
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -59,7 +59,6 @@ public class NotificationService {
         ));
     }
 
-    @Transactional(readOnly = true)
     public Page<NotificationResponse> searchNotifications(NotificationSearchCondition condition, Pageable pageable) {
         Page<Notification> result;
 
@@ -80,8 +79,7 @@ public class NotificationService {
         // 결과가 비어있어도 404를 던지지 않고 빈 페이지 반환 (200 OK 일관성 유지)
         return result.map(NotificationResponse::from);
     }
-
-    @Transactional(readOnly = true)
+    
     public NotificationResponse getNotification(UUID id) {
         return notificationRepository.findByIdAndDeletedAtIsNull(id)
             .map(NotificationResponse::from)

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -5,6 +5,8 @@ import com.team.notificationservice.domain.NotificationRepository;
 import com.team.notificationservice.domain.SendStatus;
 import com.team.notificationservice.infrastructure.SlackClient;
 import com.team.notificationservice.presentation.NotificationResponse;
+import com.team.notificationservice.presentation.common.ErrorCode;
+import com.team.notificationservice.presentation.common.ServiceException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class NotificationService {
 
@@ -23,64 +26,73 @@ public class NotificationService {
 
     @Transactional
     public void createAndSend(NotificationRequest dto) {
-        String targetSlackId = dto.getReceiverSlackId();
+        String targetSlackId = dto.receiverSlackId();
 
+        // 1. 대상자 식별 예외 처리
         // ID가 없고 이메일이 있다면 이메일로 ID 조회
-        if ((targetSlackId == null || targetSlackId.isEmpty()) && dto.getEmail() != null) {
-            targetSlackId = slackClient.findSlackIdByEmail(dto.getEmail());
+        if ((targetSlackId == null || targetSlackId.isEmpty()) && dto.email() != null) {
+            targetSlackId = slackClient.findSlackIdByEmail(dto.email());
         }
 
         if (targetSlackId == null) {
-            log.error("대상자를 특정할 수 없습니다.");
-            return;
+            log.error("대상슬랙 ID를 찾을 수 없습니다. Email: {}", dto.email());
+            throw new ServiceException(ErrorCode.NOTI_RECIPIENT_NOT_FOUND);
         }
 
         Notification notification = Notification.builder()
-                .receiverSlackId(targetSlackId) // 조회된 혹은 입력된 ID 저장
-                .orderId(dto.getOrderId())
-                .msgContent(dto.getMessage())
-                .msgType(dto.getMsgType())
-                .sendStatus(SendStatus.PENDING)
-                .build();
+            .receiverSlackId(targetSlackId) // 조회된 혹은 입력된 ID 저장
+            .orderId(dto.orderId())
+            .msgContent(dto.message())
+            .msgType(dto.msgType())
+            .sendStatus(SendStatus.PENDING)
+            .build();
 
         notificationRepository.save(notification);
 
+        // 2. 외부 서비스(슬랙) 호출 예외 처리
         // 실제 발송
-        boolean success = slackClient.sendDirectMessage(targetSlackId, notification.getMsgContent());
+        try {
+            boolean success = slackClient.sendDirectMessage(targetSlackId, notification.getMsgContent());
 
-        if (success) {
-            notification.markAsSuccess();
-        } else {
+            if (success) {
+                notification.markAsSuccess();
+            } else {
+                notification.markAsFailed();
+            }
+        } catch (Exception e) {
+            log.error("슬랙 발송 중 시스템 오류 발생: {}", e.getMessage());
             notification.markAsFailed();
+            throw new ServiceException(ErrorCode.NOTI_SLACK_API_ERROR);
         }
     }
 
     @Transactional(readOnly = true)
     public Page<NotificationResponse> searchNotifications(NotificationSearchCondition condition, Pageable pageable) {
         // 키워드가 있으면 포함 검색, 없으면 기존대로 전체 조회
-        if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
+        if (condition.keyword() != null && !condition.keyword().isBlank()) {
             return notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
-                            condition.getSlackId(), condition.getKeyword(), pageable)
-                    .map(NotificationResponse::from);
+                    condition.slackId(), condition.keyword(), pageable)
+                .map(NotificationResponse::from);
         }
 
         return notificationRepository.findByReceiverSlackIdAndDeletedAtIsNull(
-                        condition.getSlackId(), pageable)
-                .map(NotificationResponse::from);
+                condition.slackId(), pageable)
+            .map(NotificationResponse::from);
     }
 
     @Transactional(readOnly = true)
     public NotificationResponse getNotification(UUID id) {
+        // 3. 존재하지 않는 자원에 대한 구체적 예외 발생
         return notificationRepository.findByIdAndDeletedAtIsNull(id)
-                .map(NotificationResponse::from)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 삭제된 알림입니다."));
+            .map(NotificationResponse::from)
+            .orElseThrow(() -> new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
     }
 
     @Transactional
     public void deleteNotification(UUID id, String deletedBy) {
-        // 삭제되지 않은 알림을 찾아서
+        // 4. 삭제 대상 부재 시 예외 발생
         Notification notification = notificationRepository.findByIdAndDeletedAtIsNull(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 이미 삭제된 알림입니다."));
+            .orElseThrow(() -> new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
 
         // 엔티티에 삭제 처리를 위임
         notification.delete(deletedBy);

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -10,6 +10,7 @@ import com.team.notificationservice.presentation.common.ServiceException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,13 +23,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
-    private final SlackClient slackClient;
+    private final SlackClient slackClient;// Listener로 옮길 예정이지만, ID 조회 로직 때문에 유지
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void createAndSend(NotificationRequest dto) {
         String targetSlackId = dto.receiverSlackId();
 
-        // 1. 대상자 식별 예외 처리
+        // 대상자 식별 예외 처리
         // ID가 없고 이메일이 있다면 이메일로 ID 조회
         if ((targetSlackId == null || targetSlackId.isEmpty()) && dto.email() != null) {
             targetSlackId = slackClient.findSlackIdByEmail(dto.email());
@@ -49,40 +51,36 @@ public class NotificationService {
 
         notificationRepository.save(notification);
 
-        // 2. 외부 서비스(슬랙) 호출 예외 처리
-        // 실제 발송
-        try {
-            boolean success = slackClient.sendDirectMessage(targetSlackId, notification.getMsgContent());
-
-            if (success) {
-                notification.markAsSuccess();
-            } else {
-                notification.markAsFailed();
-            }
-        } catch (Exception e) {
-            log.error("슬랙 발송 중 시스템 오류 발생: {}", e.getMessage());
-            notification.markAsFailed();
-            throw new ServiceException(ErrorCode.NOTI_SLACK_API_ERROR);
-        }
+        // 슬랙 발송 로직 대신 이벤트를 던짐
+        eventPublisher.publishEvent(new NotificationCreatedEvent(
+            notification.getId(),
+            targetSlackId,
+            notification.getMsgContent()
+        ));
     }
 
     @Transactional(readOnly = true)
     public Page<NotificationResponse> searchNotifications(NotificationSearchCondition condition, Pageable pageable) {
-        // 키워드가 있으면 포함 검색, 없으면 기존대로 전체 조회
+        Page<Notification> result;
+
         if (condition.keyword() != null && !condition.keyword().isBlank()) {
-            return notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
-                    condition.slackId(), condition.keyword(), pageable)
-                .map(NotificationResponse::from);
+            result = notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
+                condition.slackId(), condition.keyword(), pageable);
+        } else {
+            result = notificationRepository.findByReceiverSlackIdAndDeletedAtIsNull(
+                condition.slackId(), pageable);
         }
 
-        return notificationRepository.findByReceiverSlackIdAndDeletedAtIsNull(
-                condition.slackId(), pageable)
-            .map(NotificationResponse::from);
+        // 결과가 비어있으면 404 예외 발생
+        if (result.isEmpty()) {
+            throw new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND);
+        }
+
+        return result.map(NotificationResponse::from);
     }
 
     @Transactional(readOnly = true)
     public NotificationResponse getNotification(UUID id) {
-        // 3. 존재하지 않는 자원에 대한 구체적 예외 발생
         return notificationRepository.findByIdAndDeletedAtIsNull(id)
             .map(NotificationResponse::from)
             .orElseThrow(() -> new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
@@ -90,7 +88,7 @@ public class NotificationService {
 
     @Transactional
     public void deleteNotification(UUID id, String deletedBy) {
-        // 4. 삭제 대상 부재 시 예외 발생
+        // 삭제 대상 부재 시 예외 발생
         Notification notification = notificationRepository.findByIdAndDeletedAtIsNull(id)
             .orElseThrow(() -> new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
 

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -31,12 +31,13 @@ public class NotificationService {
         String targetSlackId = dto.receiverSlackId();
 
         // 대상자 식별 예외 처리
-        // ID가 없고 이메일이 있다면 이메일로 ID 조회
-        if ((targetSlackId == null || targetSlackId.isEmpty()) && dto.email() != null) {
+        // targetSlackId가 없거나 공백인 경우, 이메일이 유효하다면(공백 아님) 조회 시도
+        if ((targetSlackId == null || targetSlackId.isBlank()) && dto.email() != null && !dto.email().isBlank()) {
             targetSlackId = slackClient.findSlackIdByEmail(dto.email());
         }
 
-        if (targetSlackId == null) {
+        // 최종 결과가 여전히 비어있거나 공백이면 예외 발생
+        if (targetSlackId == null || targetSlackId.isBlank()) {
             log.error("대상슬랙 ID를 찾을 수 없습니다. Email: {}", dto.email());
             throw new ServiceException(ErrorCode.NOTI_RECIPIENT_NOT_FOUND);
         }
@@ -70,16 +71,10 @@ public class NotificationService {
                 condition.slackId(), pageable);
         }
 
-//        // 결과가 비어있으면 404 예외 발생
-//        if (result.isEmpty()) {
-//            throw new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND);
-//        }
-//        return result.map(NotificationResponse::from);
-
         // 결과가 비어있어도 404를 던지지 않고 빈 페이지 반환 (200 OK 일관성 유지)
         return result.map(NotificationResponse::from);
     }
-    
+
     public NotificationResponse getNotification(UUID id) {
         return notificationRepository.findByIdAndDeletedAtIsNull(id)
             .map(NotificationResponse::from)

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -10,7 +10,9 @@ import com.team.notificationservice.presentation.common.ServiceException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,22 +28,30 @@ public class NotificationService {
     private final SlackClient slackClient;// Listener로 옮길 예정이지만, ID 조회 로직 때문에 유지
     private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
+    private NotificationService self;
+
+    // 자기 자신을 주입받아 프록시를 통한 트랜잭션 호출 보장
+    @Autowired
+    public void setSelf(@Lazy NotificationService self) {
+        this.self = self;
+    }
+
+    /**
+     * 알림 생성 및 전송 엔트리 포인트 네트워크 호출(Slack API)을 포함하므로 @Transactional을 붙이지 않음!
+     */
     public void createAndSend(NotificationRequest dto) {
-        String targetSlackId = dto.receiverSlackId();
+        // 1. 수신자 식별 (네트워크 호출 포함 가능성) - 트랜잭션 밖에서 수행
+        String targetSlackId = resolveTargetSlackId(dto);
 
-        // 대상자 식별 예외 처리
-        // targetSlackId가 없거나 공백인 경우, 이메일이 유효하다면(공백 아님) 조회 시도
-        if ((targetSlackId == null || targetSlackId.isBlank()) && dto.email() != null && !dto.email().isBlank()) {
-            targetSlackId = slackClient.findSlackIdByEmail(dto.email());
-        }
+        // 2. 실제 DB 저장 및 이벤트 발행 - 별도 트랜잭션 메서드 호출
+        self.saveAndPublish(dto, targetSlackId);
+    }
 
-        // 최종 결과가 여전히 비어있거나 공백이면 예외 발생
-        if (targetSlackId == null || targetSlackId.isBlank()) {
-            log.error("대상슬랙 ID를 찾을 수 없습니다. Email: {}", dto.email());
-            throw new ServiceException(ErrorCode.NOTI_RECIPIENT_NOT_FOUND);
-        }
-
+    /**
+     * 실제 DB 저장 및 이벤트를 발행하는 핵심 로직 쓰기 트랜잭션 범위를 최소화
+     */
+    @Transactional
+    public void saveAndPublish(NotificationRequest dto, String targetSlackId) {
         Notification notification = Notification.builder()
             .receiverSlackId(targetSlackId) // 조회된 혹은 입력된 ID 저장
             .orderId(dto.orderId())
@@ -58,6 +68,38 @@ public class NotificationService {
             targetSlackId,
             notification.getMsgContent()
         ));
+    }
+
+    /**
+     * 수신자 Slack ID 식별 로직
+     */
+    private String resolveTargetSlackId(NotificationRequest dto) {
+        String targetSlackId = dto.receiverSlackId();
+
+        // targetSlackId가 없거나 공백인 경우, 이메일이 유효하다면 Slack API 호출
+        if ((targetSlackId == null || targetSlackId.isBlank()) && dto.email() != null && !dto.email().isBlank()) {
+            targetSlackId = slackClient.findSlackIdByEmail(dto.email());
+        }
+
+        // 최종 결과가 여전히 비어있거나 공백이면 예외 발생
+        if (targetSlackId == null || targetSlackId.isBlank()) {
+            // 개인정보 보안을 위해 이메일 마스킹 처리 후 로그 기록
+            String maskedEmail = maskEmail(dto.email());
+            log.error("대상 슬랙 ID를 찾을 수 없습니다. Email: {}, OrderId: {}", maskedEmail, dto.orderId());
+            throw new ServiceException(ErrorCode.NOTI_RECIPIENT_NOT_FOUND);
+        }
+        return targetSlackId;
+    }
+
+    /**
+     * 이메일 마스킹 처리 (개인정보 보호)
+     */
+    private String maskEmail(String email) {
+        if (email == null || !email.contains("@")) {
+            return "UNKNOWN";
+        }
+        // 앞 두 글자만 남기고 나머지는 마스킹 (예: te***@domain.com)
+        return email.replaceAll("(^[^@]{2}|(?!^)\\G)[^@]", "$1*");
     }
 
     public Page<NotificationResponse> searchNotifications(NotificationSearchCondition condition, Pageable pageable) {

--- a/notification-service/src/main/java/com/team/notificationservice/domain/NotificationRepository.java
+++ b/notification-service/src/main/java/com/team/notificationservice/domain/NotificationRepository.java
@@ -11,7 +11,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
     Page<Notification> findByReceiverSlackIdAndDeletedAtIsNull(String slackId, Pageable pageable);
 
     Page<Notification> findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
-            String slackId, String msgContent, Pageable pageable);
+        String slackId, String msgContent, Pageable pageable);
 
     Optional<Notification> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,6 +29,10 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+
+    //    @Value("${internal.auth.token}")
+    private String internalAuthToken;
+
     // 외부용 API
     @PostMapping("/api/v1/notifications/slack")
     public ApiResponse<String> send(@RequestBody @Valid NotificationRequest request) {
@@ -43,7 +46,7 @@ public class NotificationController {
                                             @RequestBody @Valid NotificationRequest request) {
 
         // 내부 호출 인증 체크 (예시?)
-        if (token == null || !token.equals("INTERNAL_SECRET")) {
+        if (token == null || !token.equals(internalAuthToken)) {
             throw new ServiceException(ErrorCode.COMMON_INVALID_INPUT_VALUE); // notification 권한 에러 코드로 대체하기
         }
 
@@ -65,13 +68,13 @@ public class NotificationController {
     }
 
     @DeleteMapping("/api/v1/notifications/{id}")
-    public ResponseEntity<Void> delete(
+    public ApiResponse<Void> delete(
         @PathVariable UUID id,
         @RequestHeader(value = "X-User-Id", required = false) String userId) {
 
         String deletedBy = (userId != null) ? userId : "SYSTEM";
         notificationService.deleteNotification(id, deletedBy);
 
-        return ResponseEntity.noContent().build();
+        return ApiResponse.ok();
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -3,6 +3,7 @@ package com.team.notificationservice.presentation;
 import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
+import com.team.notificationservice.presentation.common.ApiResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -29,36 +31,36 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @PostMapping("/slack")
-    public ResponseEntity<String> send(@RequestBody NotificationRequest request) {
+    public ApiResponse<String> send(@RequestBody NotificationRequest request) {
         log.info("알림 서비스 요청 수신: {}", request); // 요청이 들어오는지 확인
         notificationService.createAndSend(request);
-        return ResponseEntity.ok("OK");
-    }
-
-    @GetMapping
-    public ResponseEntity<Page<NotificationResponse>> getNotifications(
-            NotificationSearchCondition condition,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-
-        return ResponseEntity.ok(notificationService.searchNotifications(condition, pageable));
+        return ApiResponse.success("OK");
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<NotificationResponse> getNotification(@PathVariable UUID id) {
-        NotificationResponse response = notificationService.getNotification(id);
-        return ResponseEntity.ok(response);
+    public ApiResponse<NotificationResponse> getNotification(@PathVariable UUID id) {
+        return ApiResponse.success(notificationService.getNotification(id));
+    }
+
+    @GetMapping
+    public ApiResponse<Page<NotificationResponse>> getNotifications(
+        NotificationSearchCondition condition,
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ApiResponse.success(notificationService.searchNotifications(condition, pageable));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(
-            @PathVariable UUID id,
-            @RequestHeader(value = "X-User-Id", required = false) String userId) {
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ApiResponse<Void> delete(
+        @PathVariable UUID id,
+        @RequestHeader(value = "X-User-Id", required = false) String userId) {
 
         // 헤더값이 없으면 기본값 "SYSTEM" 사용
         String deletedBy = (userId != null) ? userId : "SYSTEM";
 
         notificationService.deleteNotification(id, deletedBy);
 
-        return ResponseEntity.noContent().build();
+        return ApiResponse.success(null);
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -30,7 +31,7 @@ public class NotificationController {
     private final NotificationService notificationService;
 
 
-    //    @Value("${internal.auth.token}")
+    @Value("${internal.auth.token:}") // application.yml 미설정 시 빈 값 주입
     private String internalAuthToken;
 
     // 외부용 API
@@ -42,12 +43,13 @@ public class NotificationController {
 
     // 내부 시스템 호출용 (게이트웨이 설정 없이 서비스명:8085/internal/v1/... 으로 직접 호출)
     @PostMapping("/internal/v1/notifications/slack")
-    public ApiResponse<String> internalSend(@RequestHeader(value = "X-Internal-Token", required = false) String token,
-                                            @RequestBody @Valid NotificationRequest request) {
+    public ApiResponse<String> internalSend(
+        @RequestHeader(value = "X-Internal-Token", required = false) String token,
+        @RequestBody @Valid NotificationRequest request) {
 
-        // 내부 호출 인증 체크 (예시?)
-        if (token == null || !token.equals(internalAuthToken)) {
-            throw new ServiceException(ErrorCode.COMMON_INVALID_INPUT_VALUE); // notification 권한 에러 코드로 대체하기
+        // 서버 설정 토큰이 비어있거나, 입력 토큰이 일치하지 않는 경우 차단
+        if (internalAuthToken.isBlank() || token == null || !token.equals(internalAuthToken)) {
+            throw new ServiceException(ErrorCode.COMMON_INVALID_INPUT_VALUE);
         }
 
         notificationService.createAndSend(request);
@@ -75,6 +77,6 @@ public class NotificationController {
         String deletedBy = (userId != null) ? userId : "SYSTEM";
         notificationService.deleteNotification(id, deletedBy);
 
-        return ApiResponse.ok();
+        return ApiResponse.success(null);
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -4,6 +4,8 @@ import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
 import com.team.notificationservice.presentation.common.ApiResponse;
+import com.team.notificationservice.presentation.common.ErrorCode;
+import com.team.notificationservice.presentation.common.ServiceException;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +14,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -38,7 +39,14 @@ public class NotificationController {
 
     // 내부 시스템 호출용 (게이트웨이 설정 없이 서비스명:8085/internal/v1/... 으로 직접 호출)
     @PostMapping("/internal/v1/notifications/slack")
-    public ApiResponse<String> internalSend(@RequestBody @Valid NotificationRequest request) {
+    public ApiResponse<String> internalSend(@RequestHeader(value = "X-Internal-Token", required = false) String token,
+                                            @RequestBody @Valid NotificationRequest request) {
+
+        // 내부 호출 인증 체크 (예시?)
+        if (token == null || !token.equals("INTERNAL_SECRET")) {
+            throw new ServiceException(ErrorCode.COMMON_INVALID_INPUT_VALUE); // notification 권한 에러 코드로 대체하기
+        }
+
         notificationService.createAndSend(request);
         return ApiResponse.success("OK");
     }
@@ -57,16 +65,13 @@ public class NotificationController {
     }
 
     @DeleteMapping("/api/v1/notifications/{id}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public ApiResponse<Void> delete(
+    public ResponseEntity<Void> delete(
         @PathVariable UUID id,
         @RequestHeader(value = "X-User-Id", required = false) String userId) {
 
-        // 헤더값이 없으면 기본값 "SYSTEM" 사용
         String deletedBy = (userId != null) ? userId : "SYSTEM";
-
         notificationService.deleteNotification(id, deletedBy);
 
-        return ApiResponse.success(null);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -47,9 +47,15 @@ public class NotificationController {
         @RequestHeader(value = "X-Internal-Token", required = false) String token,
         @RequestBody @Valid NotificationRequest request) {
 
-        // 서버 설정 토큰이 비어있거나, 입력 토큰이 일치하지 않는 경우 차단
-        if (internalAuthToken.isBlank() || token == null || !token.equals(internalAuthToken)) {
-            throw new ServiceException(ErrorCode.COMMON_INVALID_INPUT_VALUE);
+        // 1. 서버 설정 체크 (5xx)
+        if (internalAuthToken == null || internalAuthToken.isBlank()) {
+            log.error("Internal Auth Token is not configured in server.");
+            throw new ServiceException(ErrorCode.SERVER_CONFIG_ERROR);
+        }
+
+        // 2. 토큰 유효성 체크 (401)
+        if (token == null || !token.equals(internalAuthToken)) {
+            throw new ServiceException(ErrorCode.AUTH_INVALID_TOKEN);
         }
 
         notificationService.createAndSend(request);
@@ -74,7 +80,8 @@ public class NotificationController {
         @PathVariable UUID id,
         @RequestHeader(value = "X-User-Id", required = false) String userId) {
 
-        String deletedBy = (userId != null) ? userId : "SYSTEM";
+        // 빈 문자열이나 공백도 SYSTEM으로 정규화
+        String deletedBy = (userId != null && !userId.isBlank()) ? userId : "SYSTEM";
         notificationService.deleteNotification(id, deletedBy);
 
         return ApiResponse.success(null);

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -4,6 +4,7 @@ import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
 import com.team.notificationservice.presentation.common.ApiResponse;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,39 +19,44 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
 public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @PostMapping("/slack")
-    public ApiResponse<String> send(@RequestBody NotificationRequest request) {
-        log.info("알림 서비스 요청 수신: {}", request); // 요청이 들어오는지 확인
+    // 외부용 API
+    @PostMapping("/api/v1/notifications/slack")
+    public ApiResponse<String> send(@RequestBody @Valid NotificationRequest request) {
         notificationService.createAndSend(request);
         return ApiResponse.success("OK");
     }
 
-    @GetMapping("/{id}")
+    // 내부 시스템 호출용 (게이트웨이 설정 없이 서비스명:8085/internal/v1/... 으로 직접 호출)
+    @PostMapping("/internal/v1/notifications/slack")
+    public ApiResponse<String> internalSend(@RequestBody @Valid NotificationRequest request) {
+        notificationService.createAndSend(request);
+        return ApiResponse.success("OK");
+    }
+
+    @GetMapping("/api/v1/notifications/{id}")
     public ApiResponse<NotificationResponse> getNotification(@PathVariable UUID id) {
         return ApiResponse.success(notificationService.getNotification(id));
     }
 
-    @GetMapping
+    @GetMapping("/api/v1/notifications")
     public ApiResponse<Page<NotificationResponse>> getNotifications(
-        NotificationSearchCondition condition,
+        @Valid NotificationSearchCondition condition,
         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return ApiResponse.success(notificationService.searchNotifications(condition, pageable));
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/api/v1/notifications/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public ApiResponse<Void> delete(
         @PathVariable UUID id,

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationResponse.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationResponse.java
@@ -5,22 +5,20 @@ import com.team.notificationservice.domain.SendStatus;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class NotificationResponse {
-    private UUID id;
-    private String message;
-    private SendStatus status;
-    private LocalDateTime createdAt;
-
+public record NotificationResponse(
+    UUID id,
+    String message,
+    SendStatus status,
+    LocalDateTime createdAt
+) {
     public static NotificationResponse from(Notification notification) {
         return NotificationResponse.builder()
-                .id(notification.getId())
-                .message(notification.getMsgContent())
-                .status(notification.getSendStatus())
-                .createdAt(notification.getCreatedAt())
-                .build();
+            .id(notification.getId())
+            .message(notification.getMsgContent())
+            .status(notification.getSendStatus())
+            .createdAt(notification.getCreatedAt())
+            .build();
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ApiResponse.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ApiResponse.java
@@ -1,20 +1,32 @@
 package com.team.notificationservice.presentation.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
 public record ApiResponse<T>(
     boolean success,
     T data,
     String code,
-    String message
+    String message,
+    @JsonInclude(JsonInclude.Include.NON_NULL) //에러가 없을 땐 응답에서 제외
+    List<ValidationError> errors
 ) {
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, data, "SUCCESS", "요청에 성공하였습니다.");
+        return new ApiResponse<>(true, data, "SUCCESS", "요청에 성공하였습니다.", null);
     }
 
     public static ApiResponse<Void> ok() {
-        return new ApiResponse<>(true, null, "SUCCESS", "요청이 성공했습니다.");
+        return new ApiResponse<>(true, null, "SUCCESS", "요청이 성공했습니다.", null);
     }
 
     public static ApiResponse<Void> error(String code, String message) {
-        return new ApiResponse<>(false, null, code, message);
+        return new ApiResponse<>(false, null, code, message, null);
+    }
+
+    public static ApiResponse<Void> error(String code, String message, List<ValidationError> errors) {
+        return new ApiResponse<>(false, null, code, message, errors);
+    }
+
+    public record ValidationError(String field, String value, String reason) {
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ApiResponse.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ApiResponse.java
@@ -11,12 +11,14 @@ public record ApiResponse<T>(
     @JsonInclude(JsonInclude.Include.NON_NULL) //에러가 없을 땐 응답에서 제외
     List<ValidationError> errors
 ) {
+    private static final String DEFAULT_SUCCESS_MESSAGE = "요청에 성공하였습니다.";
+
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, data, "SUCCESS", "요청에 성공하였습니다.", null);
+        return new ApiResponse<>(true, data, "SUCCESS", DEFAULT_SUCCESS_MESSAGE, null);
     }
 
     public static ApiResponse<Void> ok() {
-        return new ApiResponse<>(true, null, "SUCCESS", "요청이 성공했습니다.", null);
+        return new ApiResponse<>(true, null, "SUCCESS", DEFAULT_SUCCESS_MESSAGE, null);
     }
 
     public static ApiResponse<Void> error(String code, String message) {

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ApiResponse.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ApiResponse.java
@@ -1,0 +1,20 @@
+package com.team.notificationservice.presentation.common;
+
+public record ApiResponse<T>(
+    boolean success,
+    T data,
+    String code,
+    String message
+) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, "SUCCESS", "요청에 성공하였습니다.");
+    }
+
+    public static ApiResponse<Void> ok() {
+        return new ApiResponse<>(true, null, "SUCCESS", "요청이 성공했습니다.");
+    }
+
+    public static ApiResponse<Void> error(String code, String message) {
+        return new ApiResponse<>(false, null, code, message);
+    }
+}

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ErrorCode.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ErrorCode.java
@@ -12,9 +12,9 @@ public enum ErrorCode {
     COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
 
     // 알림 서비스 전용 에러
-    NOTI_NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND_NOTIFICATION", "해당 알림을 찾을 수 없거나 이미 삭제되었습니다."),
-    NOTI_RECIPIENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOT_FOUND_RECIPIENT", "알림 수신 대상자(슬랙 ID 또는 이메일)를 찾을 수 없습니다."),
-    NOTI_SLACK_API_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "SLACK_API_ERROR", "슬랙 메시지 전송 중 외부 서비스 오류가 발생했습니다.");
+    NOTI_RECIPIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI_RECIPIENT_NOT_FOUND", "알림 수신 대상자(슬랙 ID 또는 이메일)를 찾을 수 없습니다."),
+    NOTI_NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI_NOT_FOUND", "해당 알림 정보를 찾을 수 없습니다."),
+    NOTI_SLACK_API_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "NOTI_SLACK_ERROR", "슬랙 API 호출 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ErrorCode.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.team.notificationservice.presentation.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 공통 에러
+    COMMON_INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "입력값이 올바르지 않습니다."),
+    COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
+
+    // 알림 서비스 전용 에러
+    NOTI_NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND_NOTIFICATION", "해당 알림을 찾을 수 없거나 이미 삭제되었습니다."),
+    NOTI_RECIPIENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOT_FOUND_RECIPIENT", "알림 수신 대상자(슬랙 ID 또는 이메일)를 찾을 수 없습니다."),
+    NOTI_SLACK_API_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "SLACK_API_ERROR", "슬랙 메시지 전송 중 외부 서비스 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ErrorCode.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ErrorCode.java
@@ -7,6 +7,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_INVALID_TOKEN", "인증 토큰이 유효하지 않습니다."),
+    SERVER_CONFIG_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_CONFIG_MISSING", "서버 설정 정보가 누락되었습니다."),
+    
     // 공통 에러
     COMMON_INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "입력값이 올바르지 않습니다."),
     COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/GlobalExceptionHandler.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.team.notificationservice.presentation.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ServiceException.class)
+    public ResponseEntity<ApiResponse<Void>> handleServiceException(ServiceException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("ServiceException: {}", errorCode.getMessage());
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(ApiResponse.error(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(Exception e) {
+        log.error("ValidationException: {}", e.getMessage());
+        return ResponseEntity
+            .badRequest()
+            .body(ApiResponse.error(
+                ErrorCode.COMMON_INVALID_INPUT_VALUE.getCode(),
+                ErrorCode.COMMON_INVALID_INPUT_VALUE.getMessage()
+            ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled Exception: ", e); // 모든 예외 로깅
+        return ResponseEntity
+            .status(ErrorCode.COMMON_INTERNAL_SERVER_ERROR.getStatus())
+            .body(ApiResponse.error(
+                ErrorCode.COMMON_INTERNAL_SERVER_ERROR.getCode(),
+                ErrorCode.COMMON_INTERNAL_SERVER_ERROR.getMessage()
+            ));
+    }
+}

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/GlobalExceptionHandler.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/GlobalExceptionHandler.java
@@ -2,9 +2,11 @@ package com.team.notificationservice.presentation.common;
 
 import com.team.notificationservice.presentation.common.ApiResponse.ValidationError;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -28,7 +30,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
     public ResponseEntity<ApiResponse<Void>> handleValidationException(BindException e) {
-        log.error("ValidationException: {}", e.getMessage());
+        // 보안을 위해 원본 메시지(e.getMessage()) 대신 필드명과 에러 개수만 로깅
+        String fields = e.getBindingResult().getFieldErrors().stream()
+            .map(FieldError::getField)
+            .collect(Collectors.joining(", "));
+        log.warn("ValidationException: {} field error(s) in [{}]", e.getBindingResult().getFieldErrorCount(), fields);
 
         List<ValidationError> errors = e.getBindingResult()
             .getFieldErrors()

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/GlobalExceptionHandler.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/GlobalExceptionHandler.java
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
             .stream()
             .map(error -> new ApiResponse.ValidationError(
                 error.getField(),
-                String.valueOf(error.getRejectedValue()),
+                maskSensitiveInfo(error.getField(), String.valueOf(error.getRejectedValue())),
                 error.getDefaultMessage()))
             .toList();
 
@@ -46,6 +46,17 @@ public class GlobalExceptionHandler {
                 ErrorCode.COMMON_INVALID_INPUT_VALUE.getMessage(),
                 errors
             ));
+    }
+
+    // 민감 정보 마스킹 로직 (예: 이메일)
+    private String maskSensitiveInfo(String field, String value) {
+        if (value == null || value.equals("null")) {
+            return value;
+        }
+        if (field.toLowerCase().contains("email") && value.contains("@")) {
+            return value.replaceAll("(^[^@]{3}|(?!^)\\G)[^@]", "$1*");
+        }
+        return value;
     }
 
     @ExceptionHandler(Exception.class)

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/GlobalExceptionHandler.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.team.notificationservice.presentation.common;
 
+import com.team.notificationservice.presentation.common.ApiResponse.ValidationError;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -17,17 +19,32 @@ public class GlobalExceptionHandler {
         log.error("ServiceException: {}", errorCode.getMessage());
         return ResponseEntity
             .status(errorCode.getStatus())
-            .body(ApiResponse.error(errorCode.getCode(), errorCode.getMessage()));
+            .body(ApiResponse.error(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                e.getErrors()
+            ));
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
-    public ResponseEntity<ApiResponse<Void>> handleValidationException(Exception e) {
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(BindException e) {
         log.error("ValidationException: {}", e.getMessage());
+
+        List<ValidationError> errors = e.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .map(error -> new ApiResponse.ValidationError(
+                error.getField(),
+                String.valueOf(error.getRejectedValue()),
+                error.getDefaultMessage()))
+            .toList();
+
         return ResponseEntity
             .badRequest()
             .body(ApiResponse.error(
                 ErrorCode.COMMON_INVALID_INPUT_VALUE.getCode(),
-                ErrorCode.COMMON_INVALID_INPUT_VALUE.getMessage()
+                ErrorCode.COMMON_INVALID_INPUT_VALUE.getMessage(),
+                errors
             ));
     }
 

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
@@ -1,0 +1,14 @@
+package com.team.notificationservice.presentation.common;
+
+public class ServiceException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ServiceException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
@@ -21,6 +21,13 @@ public class ServiceException extends RuntimeException {
         this.errors = errors;
     }
 
+    // 원인 보존을 위한 생성자 추가
+    public ServiceException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+        this.errors = null;
+    }
+
     public ErrorCode getErrorCode() {
         return errorCode;
     }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
@@ -1,14 +1,31 @@
 package com.team.notificationservice.presentation.common;
 
+import java.util.List;
+
 public class ServiceException extends RuntimeException {
     private final ErrorCode errorCode;
+    // 상세 에러 정보를 담을 리스트 추가
+    private final List<ApiResponse.ValidationError> errors;
 
+    // 기존 생성자 (상세 에러가 없는 경우)
     public ServiceException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
+        this.errors = null;
+    }
+
+    // 새로운 생성자 (상세 에러가 있는 경우)
+    public ServiceException(ErrorCode errorCode, List<ApiResponse.ValidationError> errors) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.errors = errors;
     }
 
     public ErrorCode getErrorCode() {
         return errorCode;
+    }
+
+    public List<ApiResponse.ValidationError> getErrors() {
+        return errors;
     }
 }

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
@@ -2,7 +2,7 @@ package com.team.notificationservice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -20,8 +20,6 @@ import com.team.notificationservice.domain.NotificationRepository;
 import com.team.notificationservice.domain.SendStatus;
 import com.team.notificationservice.infrastructure.SlackClient;
 import com.team.notificationservice.presentation.NotificationResponse;
-import com.team.notificationservice.presentation.common.ErrorCode;
-import com.team.notificationservice.presentation.common.ServiceException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -136,22 +134,22 @@ class NotificationServiceApplicationTests {
     }
 
     @Test
-    @DisplayName("슬랙 ID와 키워드로 검색 확인 - 결과가 없을 때 예외 발생")
-    void searchNotifications_Empty_Fail() {
+    @DisplayName("슬랙 ID와 키워드로 검색 확인 - 결과가 없을 때 빈 페이지 반환")
+    void searchNotifications_Empty_Success() {
         // given
         String slackId = "U123";
-        // 빈 결과를 반환하도록 설정
+        // 빈 결과를 반환하도록 설정 (Service에서 더 이상 예외를 던지지 않음)
         when(notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(anyString(),
             anyString(), any()))
             .thenReturn(new PageImpl<>(List.of()));
 
-        // when & then
+        // when
         NotificationSearchCondition cond = new NotificationSearchCondition(slackId, "배송");
-        ServiceException exception = assertThrows(ServiceException.class, () -> {
-            notificationService.searchNotifications(cond, PageRequest.of(0, 10));
-        });
+        Page<NotificationResponse> result = notificationService.searchNotifications(cond, PageRequest.of(0, 10));
 
-        assertEquals(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND, exception.getErrorCode());
+        // then
+        assertTrue(result.isEmpty());
+        assertEquals(0, result.getTotalElements());
     }
 
     @Test
@@ -169,15 +167,19 @@ class NotificationServiceApplicationTests {
     }
 
     @Test
-    @DisplayName("삭제(Soft Delete) 테스트")
+    @DisplayName("삭제(Soft Delete) 테스트 및 저장 호출 확인")
     void deleteNotificationTest() {
+        // given
         UUID id = UUID.randomUUID();
         Notification mockNoti = Notification.builder().msgContent("삭제").build();
         when(notificationRepository.findByIdAndDeletedAtIsNull(id)).thenReturn(Optional.of(mockNoti));
 
+        // when
         notificationService.deleteNotification(id, "user-123");
 
+        // then
         assertNotNull(mockNoti.getDeletedAt());
         assertEquals("user-123", mockNoti.getDeletedBy());
+        verify(notificationRepository, times(1)).save(mockNoti); // save 호출 여부 확인 추가
     }
 }

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
@@ -2,13 +2,15 @@ package com.team.notificationservice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.team.notificationservice.application.NotificationCreatedEvent;
 import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
@@ -18,6 +20,8 @@ import com.team.notificationservice.domain.NotificationRepository;
 import com.team.notificationservice.domain.SendStatus;
 import com.team.notificationservice.infrastructure.SlackClient;
 import com.team.notificationservice.presentation.NotificationResponse;
+import com.team.notificationservice.presentation.common.ErrorCode;
+import com.team.notificationservice.presentation.common.ServiceException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -30,127 +34,150 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
 @SpringBootTest
+@RecordApplicationEvents
 class NotificationServiceApplicationTests {
 
     @Autowired
     private NotificationService notificationService;
+
     @MockitoBean
     private NotificationRepository notificationRepository;
 
-    @MockitoBean// 실제 슬랙 API 서버를 호출하지 않도록 가짜 객체(Mock) 등록
+    @MockitoBean
     private SlackClient slackClient;
 
+    @Autowired
+    private ApplicationEvents applicationEvents;
+
     @Test
-    @DisplayName("슬랙 알림 생성 및 발송 프로세스 통합 테스트")
+    @DisplayName("슬랙 알림 생성 및 이벤트 발행 검증")
     void notificationSendTest() {
-        // given: 테스트용 데이터 준비 - Record 생성자 사용
-        NotificationRequest request = new NotificationRequest("U12345678", null, UUID.randomUUID(), "테스트 알림 메시지입니다.",
+        // given
+        NotificationRequest request = new NotificationRequest("U12345678", null, UUID.randomUUID(), "테스트 메시지",
             MsgType.ORDER_ALERT);
+        Notification savedNoti = Notification.builder().msgContent("테스트").build();
+        when(notificationRepository.save(any())).thenReturn(savedNoti);
 
-        // 슬랙 발송 메서드가 호출되면 무조건 true를 반환하도록 설정
-        when(slackClient.sendDirectMessage(anyString(), anyString())).thenReturn(true);
-
-        // when: 알림 서비스 호출
+        // when
         notificationService.createAndSend(request);
 
-        // then: slackClient의 sendDirectMessage 메서드가 실제로 호출되었는지 검증
-        verify(slackClient, times(1)).sendDirectMessage(eq("U12345678"), eq(request.message()));
+        // then
+        // 이벤트 발행 확인
+        long count = applicationEvents.stream(NotificationCreatedEvent.class).count();
+        assertEquals(1, count);
     }
 
     @Test
-    @DisplayName("이메일 정보만 제공될 경우 슬랙 ID를 조회하여 메시지를 발송하는지 검증")
+    @DisplayName("이메일 정보만 제공될 경우 슬랙 ID를 조회하여 발송하는지 검증")
     void notificationSendWithEmailTest() {
         // given
         NotificationRequest request = new NotificationRequest(
-            null, "test@example.com", UUID.randomUUID(), "이메일 기반 ID 조회 테스트", MsgType.ORDER_ALERT
+            null, "test@example.com", UUID.randomUUID(), "이메일 기반 조회 테스트", MsgType.ORDER_ALERT
         );
 
-        // 가짜 동작 정의: 이메일로 조회 시 특정 슬랙 ID 반환
+        Notification savedNoti = Notification.builder().msgContent("이메일 테스트").build();
+        when(notificationRepository.save(any())).thenReturn(savedNoti);
+
+        // 이메일로 조회 시 가짜 ID 반환 설정
         when(slackClient.findSlackIdByEmail("test@example.com")).thenReturn("U_SEARCHED_ID");
-        when(slackClient.sendDirectMessage(anyString(), anyString())).thenReturn(true);
 
         // when
         notificationService.createAndSend(request);
 
-        // then: 1. 이메일 조회가 발생했는지 확인, 2. 조회된 ID로 발송되었는지 확인
+        // then: 1. 이메일 조회가 발생했는가? 2. 이벤트가 조회된 ID로 발행되었는가?
         verify(slackClient, times(1)).findSlackIdByEmail("test@example.com");
-        verify(slackClient, times(1)).sendDirectMessage(eq("U_SEARCHED_ID"), anyString());
+
+        long count = applicationEvents.stream(NotificationCreatedEvent.class)
+            .filter(event -> event.receiverSlackId().equals("U_SEARCHED_ID"))
+            .count();
+        assertEquals(1, count);
     }
 
     @Test
-    @DisplayName("슬랙 ID와 키워드로 검색 시 검색 결과가 반환되는지 확인")
+    @DisplayName("슬랙 ID와 키워드로 검색 확인 - 결과가 있을 때")
     void searchNotificationsMockTest() {
         // given
-        String slackId = "U12345678";
-        String keyword = "배송";
-
-        // 1. 가짜 결과 데이터 생성
-        Notification mockNotification = Notification.builder()
-            .msgContent("배송이 시작되었습니다.")
-            .receiverSlackId(slackId)
-            .sendStatus(SendStatus.SUCCESS)
-            .build();
-        Page<Notification> mockPage = new PageImpl<>(List.of(mockNotification));
-
-        // 2. 레포지토리가 이 데이터를 주도록 Mock 설정
+        String slackId = "U123";
+        Notification mockNoti = Notification.builder().msgContent("배송 완료").receiverSlackId(slackId).build();
+        // condition.keyword()가 존재할 때 호출되는 메서드를 stubbing
         when(notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
-            anyString(), anyString(), any(Pageable.class)))
-            .thenReturn(mockPage);
+            eq(slackId), eq("배송"), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of(mockNoti)));
 
         // when
-        NotificationSearchCondition condition = new NotificationSearchCondition(slackId, keyword);
-        Page<NotificationResponse> result = notificationService.searchNotifications(condition, PageRequest.of(0, 10));
+        NotificationSearchCondition cond = new NotificationSearchCondition(slackId, "배송");
+        Page<NotificationResponse> result = notificationService.searchNotifications(cond, PageRequest.of(0, 10));
 
         // then
         assertEquals(1, result.getContent().size());
-        assertEquals("배송이 시작되었습니다.", result.getContent().get(0).message());
     }
 
     @Test
-    @DisplayName("알림 ID로 단건 조회를 수행한다")
+    @DisplayName("키워드 없이 슬랙 ID로만 검색 확인 - 결과가 있을 때")
+    void searchNotifications_OnlySlackId_Success() {
+        // given
+        String slackId = "U123";
+        Notification mockNoti = Notification.builder().msgContent("전체 메시지").receiverSlackId(slackId).build();
+
+        // keyword가 null일 때 호출되는 메서드를 stubbing
+        when(notificationRepository.findByReceiverSlackIdAndDeletedAtIsNull(eq(slackId), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of(mockNoti)));
+
+        // when
+        NotificationSearchCondition cond = new NotificationSearchCondition(slackId, null);
+        Page<NotificationResponse> result = notificationService.searchNotifications(cond, PageRequest.of(0, 10));
+
+        // then
+        assertEquals(1, result.getContent().size());
+    }
+
+    @Test
+    @DisplayName("슬랙 ID와 키워드로 검색 확인 - 결과가 없을 때 예외 발생")
+    void searchNotifications_Empty_Fail() {
+        // given
+        String slackId = "U123";
+        // 빈 결과를 반환하도록 설정
+        when(notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(anyString(),
+            anyString(), any()))
+            .thenReturn(new PageImpl<>(List.of()));
+
+        // when & then
+        NotificationSearchCondition cond = new NotificationSearchCondition(slackId, "배송");
+        ServiceException exception = assertThrows(ServiceException.class, () -> {
+            notificationService.searchNotifications(cond, PageRequest.of(0, 10));
+        });
+
+        assertEquals(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("단건 조회 테스트")
     void getNotificationTest() {
-        // given
-        UUID notificationId = UUID.randomUUID();
-        Notification mockNotification = Notification.builder()
-            .msgContent("단건 조회 테스트 메시지")
-            .receiverSlackId("U12345678")
-            .sendStatus(SendStatus.SUCCESS)
-            .build();
+        UUID id = UUID.randomUUID();
+        Notification mockNoti = Notification.builder().msgContent("테스트").receiverSlackId("U1")
+            .sendStatus(SendStatus.SUCCESS).build();
+        when(notificationRepository.findByIdAndDeletedAtIsNull(id)).thenReturn(Optional.of(mockNoti));
 
-        // 레포지토리 Mock 설정
-        when(notificationRepository.findByIdAndDeletedAtIsNull(notificationId))
-            .thenReturn(Optional.of(mockNotification));
+        NotificationResponse response = notificationService.getNotification(id);
 
-        // when
-        NotificationResponse response = notificationService.getNotification(notificationId);
-
-        // then
         assertNotNull(response);
-        assertEquals("단건 조회 테스트 메시지", response.message());
-        assertEquals(SendStatus.SUCCESS, response.status());
+        assertEquals("테스트", response.message());
     }
 
     @Test
-    @DisplayName("알림 ID로 삭제 시 Soft Delete 메서드가 호출되는지 확인")
+    @DisplayName("삭제(Soft Delete) 테스트")
     void deleteNotificationTest() {
-        // given
-        UUID notificationId = UUID.randomUUID();
-        Notification mockNotification = Notification.builder()
-            .msgContent("삭제될 알림")
-            .build();
+        UUID id = UUID.randomUUID();
+        Notification mockNoti = Notification.builder().msgContent("삭제").build();
+        when(notificationRepository.findByIdAndDeletedAtIsNull(id)).thenReturn(Optional.of(mockNoti));
 
-        when(notificationRepository.findByIdAndDeletedAtIsNull(notificationId))
-            .thenReturn(Optional.of(mockNotification));
+        notificationService.deleteNotification(id, "user-123");
 
-        // when
-        notificationService.deleteNotification(notificationId, "user-123");
-
-        // then
-        // Getter를 통해 부모 필드가 정상적으로 세팅되었는지 확인
-        assertNotNull(mockNotification.getDeletedAt());
-        assertEquals("user-123", mockNotification.getDeletedBy());
-//        assertEquals(SendStatus.CANCEL, mockNotification.getSendStatus());
+        assertNotNull(mockNoti.getDeletedAt());
+        assertEquals("user-123", mockNoti.getDeletedBy());
     }
 }

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
@@ -2,7 +2,6 @@ package com.team.notificationservice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
@@ -46,12 +45,9 @@ class NotificationServiceApplicationTests {
     @Test
     @DisplayName("슬랙 알림 생성 및 발송 프로세스 통합 테스트")
     void notificationSendTest() {
-        // given: 테스트용 데이터 준비 (현재 DTO 구조 반영)
-        NotificationRequest request = new NotificationRequest();
-        request.setReceiverSlackId("U12345678");
-        request.setOrderId(UUID.randomUUID()); // UUID 타입 반영
-        request.setMessage("테스트 알림 메시지입니다.");
-        request.setMsgType(MsgType.ORDER_ALERT);
+        // given: 테스트용 데이터 준비 - Record 생성자 사용
+        NotificationRequest request = new NotificationRequest("U12345678", null, UUID.randomUUID(), "테스트 알림 메시지입니다.",
+            MsgType.ORDER_ALERT);
 
         // 슬랙 발송 메서드가 호출되면 무조건 true를 반환하도록 설정
         when(slackClient.sendDirectMessage(anyString(), anyString())).thenReturn(true);
@@ -60,18 +56,16 @@ class NotificationServiceApplicationTests {
         notificationService.createAndSend(request);
 
         // then: slackClient의 sendDirectMessage 메서드가 실제로 호출되었는지 검증
-        verify(slackClient, times(1)).sendDirectMessage(eq("U12345678"), eq("테스트 알림 메시지입니다."));
+        verify(slackClient, times(1)).sendDirectMessage(eq("U12345678"), eq(request.message()));
     }
 
     @Test
     @DisplayName("이메일 정보만 제공될 경우 슬랙 ID를 조회하여 메시지를 발송하는지 검증")
     void notificationSendWithEmailTest() {
         // given
-        NotificationRequest request = new NotificationRequest();
-        request.setEmail("test@example.com");
-        request.setOrderId(UUID.randomUUID());
-        request.setMessage("이메일 기반 ID  조회 테스트");
-        request.setMsgType(MsgType.ORDER_ALERT);
+        NotificationRequest request = new NotificationRequest(
+            null, "test@example.com", UUID.randomUUID(), "이메일 기반 ID 조회 테스트", MsgType.ORDER_ALERT
+        );
 
         // 가짜 동작 정의: 이메일로 조회 시 특정 슬랙 ID 반환
         when(slackClient.findSlackIdByEmail("test@example.com")).thenReturn("U_SEARCHED_ID");
@@ -94,26 +88,24 @@ class NotificationServiceApplicationTests {
 
         // 1. 가짜 결과 데이터 생성
         Notification mockNotification = Notification.builder()
-                .msgContent("배송이 시작되었습니다.")
-                .receiverSlackId(slackId)
-                .sendStatus(SendStatus.SUCCESS)
-                .build();
+            .msgContent("배송이 시작되었습니다.")
+            .receiverSlackId(slackId)
+            .sendStatus(SendStatus.SUCCESS)
+            .build();
         Page<Notification> mockPage = new PageImpl<>(List.of(mockNotification));
 
         // 2. 레포지토리가 이 데이터를 주도록 Mock 설정
         when(notificationRepository.findByReceiverSlackIdAndMsgContentContainingAndDeletedAtIsNull(
-                anyString(), anyString(), any(Pageable.class)))
-                .thenReturn(mockPage);
+            anyString(), anyString(), any(Pageable.class)))
+            .thenReturn(mockPage);
 
         // when
-        NotificationSearchCondition condition = new NotificationSearchCondition();
-        condition.setSlackId(slackId);
-        condition.setKeyword(keyword);
+        NotificationSearchCondition condition = new NotificationSearchCondition(slackId, keyword);
         Page<NotificationResponse> result = notificationService.searchNotifications(condition, PageRequest.of(0, 10));
 
         // then
         assertEquals(1, result.getContent().size());
-        assertTrue(result.getContent().get(0).getMessage().contains(keyword));
+        assertEquals("배송이 시작되었습니다.", result.getContent().get(0).message());
     }
 
     @Test
@@ -122,22 +114,22 @@ class NotificationServiceApplicationTests {
         // given
         UUID notificationId = UUID.randomUUID();
         Notification mockNotification = Notification.builder()
-                .msgContent("단건 조회 테스트 메시지")
-                .receiverSlackId("U12345678")
-                .sendStatus(SendStatus.SUCCESS)
-                .build();
+            .msgContent("단건 조회 테스트 메시지")
+            .receiverSlackId("U12345678")
+            .sendStatus(SendStatus.SUCCESS)
+            .build();
 
         // 레포지토리 Mock 설정
         when(notificationRepository.findByIdAndDeletedAtIsNull(notificationId))
-                .thenReturn(Optional.of(mockNotification));
+            .thenReturn(Optional.of(mockNotification));
 
         // when
         NotificationResponse response = notificationService.getNotification(notificationId);
 
         // then
         assertNotNull(response);
-        assertEquals("단건 조회 테스트 메시지", response.getMessage());
-        assertEquals(SendStatus.SUCCESS, response.getStatus());
+        assertEquals("단건 조회 테스트 메시지", response.message());
+        assertEquals(SendStatus.SUCCESS, response.status());
     }
 
     @Test
@@ -146,11 +138,11 @@ class NotificationServiceApplicationTests {
         // given
         UUID notificationId = UUID.randomUUID();
         Notification mockNotification = Notification.builder()
-                .msgContent("삭제될 알림")
-                .build();
+            .msgContent("삭제될 알림")
+            .build();
 
         when(notificationRepository.findByIdAndDeletedAtIsNull(notificationId))
-                .thenReturn(Optional.of(mockNotification));
+            .thenReturn(Optional.of(mockNotification));
 
         // when
         notificationService.deleteNotification(notificationId, "user-123");

--- a/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
@@ -12,6 +12,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -25,9 +26,7 @@ import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationService;
 import com.team.notificationservice.domain.MsgType;
 import com.team.notificationservice.domain.SendStatus;
-import com.team.notificationservice.presentation.common.ErrorCode;
 import com.team.notificationservice.presentation.common.GlobalExceptionHandler;
-import com.team.notificationservice.presentation.common.ServiceException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -82,11 +81,13 @@ class NotificationControllerRestDocsTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 requestFields(
-                    fieldWithPath("receiverSlackId").description("수신자 슬랙 ID"),
-                    fieldWithPath("email").description("수신자 이메일").optional(),
+                    fieldWithPath("receiverSlackId").description("수신자 슬랙 ID (이메일과 둘 중 하나 필수)").optional(),
+                    fieldWithPath("email").description("수신자 이메일 (슬랙 ID와 둘 중 하나 필수)").optional(),
                     fieldWithPath("orderId").description("연관 주문 ID").optional(),
                     fieldWithPath("message").description("알림 메시지 본문"),
-                    fieldWithPath("msgType").description("메시지 타입")
+                    fieldWithPath("msgType").description("메시지 타입"),
+                    // @AssertTrue 검증 필드에 대한 문서화 누락 해결
+                    fieldWithPath("validRecipient").description("수신자 유효성 체크 필드 (내부 검증용)").ignored()
                 ),
                 responseFields(
                     fieldWithPath("success").description("성공 여부"),
@@ -100,8 +101,8 @@ class NotificationControllerRestDocsTest {
     @Test
     @DisplayName("알림 생성 실패 문서화 (Validation 에러)")
     void sendNotification_Fail() throws Exception {
-        // message와 msgType이 null인 잘못된 요청
-        NotificationRequest invalidRequest = new NotificationRequest("U123", null, null, null, null);
+        // 모든 필드가 비어있어 수신자 검증 및 필수값 검증에서 실패하는 요청
+        NotificationRequest invalidRequest = new NotificationRequest(null, null, null, null, null);
 
         mockMvc.perform(post("/api/v1/notifications/slack")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -208,39 +209,45 @@ class NotificationControllerRestDocsTest {
 
         mockMvc.perform(delete("/api/v1/notifications/{id}", id)
                 .header("X-User-Id", "ADMIN"))
-            .andExpect(status().isNoContent())
+            .andExpect(status().isOk()) // ApiResponse.ok()를 쓰므로 200 OK
             .andDo(document("notifications/delete",
-                pathParameters(parameterWithName("id").description("알림 ID"))
-                // 204 No Content 응답이므로 responseFields는 바디가 없어 생략
-            ));
-    }
-
-    @Test
-    @DisplayName("알림 목록 조회 실패 - 결과 없음")
-    void getNotifications_Fail_NotFound() throws Exception {
-        // 검색 결과가 없을 때 ServiceException을 던지는 시나리오 유지
-        given(notificationService.searchNotifications(any(), any()))
-            .willThrow(new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
-
-        mockMvc.perform(get("/api/v1/notifications")
-                .param("slackId", "INVALID_ID"))
-            .andExpect(status().isNotFound())
-            .andDo(document("notifications/list-fail",
-                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("id").description("삭제할 알림 ID")),
                 responseFields(
-                    fieldWithPath("success").description("성공 여부 (false)"),
-                    fieldWithPath("code").description("에러 코드"),
-                    fieldWithPath("message").description("에러 메시지"),
+                    fieldWithPath("success").description("성공 여부"),
                     fieldWithPath("data").description("데이터 (null)").optional(),
-                    // .type(JsonFieldType.ARRAY)를 추가하여 타입을 명시
-                    fieldWithPath("errors").type(JsonFieldType.ARRAY).description("상세 에러 목록 (null)").optional()
+                    fieldWithPath("code").description("코드"),
+                    fieldWithPath("message").description("메시지")
                 )
             ));
     }
 
+//    @Test
+//    @DisplayName("알림 목록 조회 실패 - 결과 없음")
+//    void getNotifications_Fail_NotFound() throws Exception {
+//        // 검색 결과가 없을 때 ServiceException을 던지는 시나리오 유지
+//        given(notificationService.searchNotifications(any(), any()))
+//            .willThrow(new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
+//
+//        mockMvc.perform(get("/api/v1/notifications")
+//                .param("slackId", "INVALID_ID"))
+//            .andExpect(status().isNotFound())
+//            .andDo(document("notifications/list-fail",
+//                preprocessResponse(prettyPrint()),
+//                responseFields(
+//                    fieldWithPath("success").description("성공 여부 (false)"),
+//                    fieldWithPath("code").description("에러 코드"),
+//                    fieldWithPath("message").description("에러 메시지"),
+//                    fieldWithPath("data").description("데이터 (null)").optional(),
+//                    // .type(JsonFieldType.ARRAY)를 추가하여 타입을 명시
+//                    fieldWithPath("errors").type(JsonFieldType.ARRAY).description("상세 에러 목록 (null)").optional()
+//                )
+//            ));
+//    }
+
     @Test
     @DisplayName("알림 목록 조회 실패 - 슬랙 ID 누락")
     void getNotifications_Fail_InvalidCondition() throws Exception {
+        // Validation(@Valid)에 의한 400 에러
         mockMvc.perform(get("/api/v1/notifications")
                 // slackId 파라미터를 아예 보내지 않음
                 .param("page", "0")
@@ -256,6 +263,35 @@ class NotificationControllerRestDocsTest {
                     fieldWithPath("errors[].field").description("slackId"),
                     fieldWithPath("errors[].reason").description("조회할 슬랙 ID는 필수입니다."),
                     fieldWithPath("errors[].value").description("null")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 - 결과가 없을 때 빈 목록 응답 문서화")
+    void getNotifications_Empty() throws Exception {
+        // PageRequest를 명시하여 500 에러 방지
+        given(notificationService.searchNotifications(any(), any()))
+            .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        mockMvc.perform(get("/api/v1/notifications")
+                .param("slackId", "U12345678"))
+            .andExpect(status().isOk())
+            .andDo(document("notifications/list-empty",
+                preprocessResponse(prettyPrint()),
+                queryParameters(
+                    parameterWithName("slackId").description("조회할 슬랙 ID")
+                ),
+                // relaxedResponseFields를 사용하여 명시한 필드 외에는 검증하지 않음
+                relaxedResponseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data.content").description("빈 결과 리스트"),
+                    fieldWithPath("data.totalElements").description("전체 요소 개수"),
+                    fieldWithPath("data.totalPages").description("전체 페이지 수"),
+                    fieldWithPath("data.number").description("현재 페이지 번호"),
+                    fieldWithPath("data.empty").description("비어있음 여부")
                 )
             ));
     }

--- a/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
@@ -2,6 +2,7 @@ package com.team.notificationservice.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -19,6 +20,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationService;
 import com.team.notificationservice.domain.MsgType;
@@ -49,7 +51,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class NotificationControllerRestDocsTest {
 
     private MockMvc mockMvc;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @Mock
     private NotificationService notificationService;
@@ -69,6 +71,8 @@ class NotificationControllerRestDocsTest {
         NotificationRequest request = new NotificationRequest(
             "U12345678", "test@team.com", UUID.randomUUID(), "테스트 메시지", MsgType.ORDER_ALERT
         );
+
+        doNothing().when(notificationService).createAndSend(any(NotificationRequest.class));
 
         mockMvc.perform(post("/api/v1/notifications/slack")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -200,23 +204,21 @@ class NotificationControllerRestDocsTest {
     @DisplayName("알림 삭제 API 문서화")
     void deleteNotification() throws Exception {
         UUID id = UUID.randomUUID();
+        doNothing().when(notificationService).deleteNotification(any(), any());
+
         mockMvc.perform(delete("/api/v1/notifications/{id}", id)
                 .header("X-User-Id", "ADMIN"))
             .andExpect(status().isNoContent())
             .andDo(document("notifications/delete",
-                pathParameters(parameterWithName("id").description("ID")),
-                responseFields(
-                    fieldWithPath("success").description("성공 여부"),
-                    fieldWithPath("data").description("데이터 (null)").optional(),
-                    fieldWithPath("code").description("코드"),
-                    fieldWithPath("message").description("메시지")
-                )
+                pathParameters(parameterWithName("id").description("알림 ID"))
+                // 204 No Content 응답이므로 responseFields는 바디가 없어 생략
             ));
     }
 
     @Test
     @DisplayName("알림 목록 조회 실패 - 결과 없음")
     void getNotifications_Fail_NotFound() throws Exception {
+        // 검색 결과가 없을 때 ServiceException을 던지는 시나리오 유지
         given(notificationService.searchNotifications(any(), any()))
             .willThrow(new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
 

--- a/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
@@ -3,6 +3,8 @@ package com.team.notificationservice.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -43,6 +45,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -55,9 +58,13 @@ class NotificationControllerRestDocsTest {
     @Mock
     private NotificationService notificationService;
 
+    private NotificationController notificationController;
+
     @BeforeEach
     void setUp(RestDocumentationContextProvider restDocumentation) {
-        mockMvc = MockMvcBuilders.standaloneSetup(new NotificationController(notificationService))
+        notificationController = new NotificationController(notificationService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(notificationController) // 필드에 담긴 인스턴스를 사용해야 함
             .setControllerAdvice(new GlobalExceptionHandler())
             .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
             .apply(documentationConfiguration(restDocumentation))
@@ -351,6 +358,79 @@ class NotificationControllerRestDocsTest {
                     fieldWithPath("data.totalPages").description("전체 페이지 수"),
                     fieldWithPath("data.number").description("현재 페이지 번호"),
                     fieldWithPath("data.empty").description("비어있음 여부")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("내부 알림 생성 API 성공 문서화")
+    void internalSend_Success() throws Exception {
+        // given
+        NotificationRequest request = new NotificationRequest(
+            "U12345678", "test@team.com", UUID.randomUUID(), "내부 서비스 알림", MsgType.ORDER_ALERT
+        );
+
+        // 필드로 뺀 controller에 테스트용 토큰 주입
+        ReflectionTestUtils.setField(notificationController, "internalAuthToken", "test-internal-token");
+
+        doNothing().when(notificationService).createAndSend(any(NotificationRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/internal/v1/notifications/slack")
+                .header("X-Internal-Token", "test-internal-token") // 설정한 토큰과 일치
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andDo(document("notifications/internal-create-success",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName("X-Internal-Token").description("내부 서비스 인증용 보안 토큰")
+                ),
+                requestFields(
+                    fieldWithPath("receiverSlackId").description("수신자 슬랙 ID (이메일과 둘 중 하나 필수)").optional(),
+                    fieldWithPath("email").description("수신자 이메일 (슬랙 ID와 둘 중 하나 필수)").optional(),
+                    fieldWithPath("orderId").description("연관 주문 ID").optional(),
+                    fieldWithPath("message").description("알림 메시지 본문"),
+                    fieldWithPath("msgType").description("메시지 타입"),
+                    fieldWithPath("validRecipient").description("수신자 유효성 체크 필드").ignored()
+                ),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data").description("응답 데이터 (null)").optional()
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("내부 알림 생성 API 실패 - 토큰 유효하지 않음")
+    void internalSend_Fail_InvalidToken() throws Exception {
+        // given
+        NotificationRequest request = new NotificationRequest(
+            "U12345678", "test@team.com", null, "메시지", MsgType.ORDER_ALERT
+        );
+
+        // 토큰 주입 (비어있지 않게 설정)
+        ReflectionTestUtils.setField(notificationController, "internalAuthToken", "test-internal-token");
+
+        // when & then
+        mockMvc.perform(post("/internal/v1/notifications/slack")
+                .header("X-Internal-Token", "wrong-token") // 잘못된 토큰 전달
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized()) // 401 Unauthorized 기대
+            .andDo(document("notifications/internal-create-fail-token",
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName("X-Internal-Token").description("잘못된 인증 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("success").description("false"),
+                    fieldWithPath("code").description("AUTH_INVALID_TOKEN"),
+                    fieldWithPath("message").description("인증 토큰이 유효하지 않습니다."),
+                    fieldWithPath("data").description("null").optional()
                 )
             ));
     }

--- a/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
@@ -1,9 +1,7 @@
 package com.team.notificationservice.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -25,7 +23,9 @@ import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationService;
 import com.team.notificationservice.domain.MsgType;
 import com.team.notificationservice.domain.SendStatus;
+import com.team.notificationservice.presentation.common.ErrorCode;
 import com.team.notificationservice.presentation.common.GlobalExceptionHandler;
+import com.team.notificationservice.presentation.common.ServiceException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -41,6 +41,7 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -57,17 +58,16 @@ class NotificationControllerRestDocsTest {
     void setUp(RestDocumentationContextProvider restDocumentation) {
         mockMvc = MockMvcBuilders.standaloneSetup(new NotificationController(notificationService))
             .setControllerAdvice(new GlobalExceptionHandler())
-            // Pageable 파라미터를 처리하기 위한 리졸버 등록
             .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
             .apply(documentationConfiguration(restDocumentation))
             .build();
     }
 
     @Test
-    @DisplayName("슬랙 알림 생성 및 발송 API 문서화")
+    @DisplayName("슬랙 알림 생성 API 문서화")
     void sendNotification() throws Exception {
         NotificationRequest request = new NotificationRequest(
-            "U12345678", "test@team.com", UUID.randomUUID(), "테스트 알림입니다.", MsgType.ORDER_ALERT
+            "U12345678", "test@team.com", UUID.randomUUID(), "테스트 메시지", MsgType.ORDER_ALERT
         );
 
         mockMvc.perform(post("/api/v1/notifications/slack")
@@ -94,43 +94,60 @@ class NotificationControllerRestDocsTest {
     }
 
     @Test
-    @DisplayName("알림 목록 조회 및 검색 API 문서화")
+    @DisplayName("알림 생성 실패 문서화 (Validation 에러)")
+    void sendNotification_Fail() throws Exception {
+        // message와 msgType이 null인 잘못된 요청
+        NotificationRequest invalidRequest = new NotificationRequest("U123", null, null, null, null);
+
+        mockMvc.perform(post("/api/v1/notifications/slack")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidRequest)))
+            .andExpect(status().isBadRequest())
+            .andDo(document("notifications/create-fail",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부 (false)"),
+                    fieldWithPath("code").description("에러 코드"),
+                    fieldWithPath("message").description("에러 메시지"),
+                    fieldWithPath("data").description("응답 데이터 (null)").optional(),
+                    fieldWithPath("errors").type(JsonFieldType.ARRAY).description("상세 에러 목록"),
+                    fieldWithPath("errors[].field").description("에러 발생 필드"),
+                    fieldWithPath("errors[].value").description("잘못 입력된 값"),
+                    fieldWithPath("errors[].reason").description("에러 원인")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 API 문서화")
     void getNotifications() throws Exception {
         NotificationResponse response = NotificationResponse.builder()
-            .id(UUID.randomUUID())
-            .message("검색된 메시지")
-            .status(SendStatus.SUCCESS)
-            .createdAt(LocalDateTime.now())
-            .build();
+            .id(UUID.randomUUID()).message("메시지").status(SendStatus.SUCCESS).createdAt(LocalDateTime.now()).build();
 
         given(notificationService.searchNotifications(any(), any()))
             .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1));
 
         mockMvc.perform(get("/api/v1/notifications")
                 .param("slackId", "U12345678")
-                .param("keyword", "테스트")
                 .param("page", "0")
                 .param("size", "10"))
             .andExpect(status().isOk())
             .andDo(document("notifications/list",
-                preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 queryParameters(
-                    parameterWithName("slackId").description("조회 대상 슬랙 ID"),
-                    parameterWithName("keyword").description("검색 키워드").optional(),
-                    parameterWithName("page").description("페이지 번호").optional(),
-                    parameterWithName("size").description("페이지 크기").optional()
+                    parameterWithName("slackId").description("슬랙 ID"),
+                    parameterWithName("page").description("페이지").optional(),
+                    parameterWithName("size").description("사이즈").optional()
                 ),
                 responseFields(
                     fieldWithPath("success").description("성공 여부"),
-                    fieldWithPath("code").description("응답 코드"),
-                    fieldWithPath("message").description("응답 메시지"),
-                    // Page 데이터 구조
-                    fieldWithPath("data.content[].id").description("알림 ID"),
-                    fieldWithPath("data.content[].message").description("알림 내용"),
-                    fieldWithPath("data.content[].status").description("전송 상태"),
-                    fieldWithPath("data.content[].createdAt").description("생성 시간"),
-                    // pageable 내부의 모든 필드 명시 또는 무시
+                    fieldWithPath("code").description("코드"),
+                    fieldWithPath("message").description("메시지"),
+                    fieldWithPath("data.content[].id").description("ID"),
+                    fieldWithPath("data.content[].message").description("내용"),
+                    fieldWithPath("data.content[].status").description("상태"),
+                    fieldWithPath("data.content[].createdAt").description("생성일"),
+                    // 미문서화 에러 해결: 아래 필드들 추가
                     fieldWithPath("data.pageable.pageNumber").ignored(),
                     fieldWithPath("data.pageable.pageSize").ignored(),
                     fieldWithPath("data.pageable.sort.sorted").ignored(),
@@ -139,17 +156,17 @@ class NotificationControllerRestDocsTest {
                     fieldWithPath("data.pageable.offset").ignored(),
                     fieldWithPath("data.pageable.paged").ignored(),
                     fieldWithPath("data.pageable.unpaged").ignored(),
-                    fieldWithPath("data.totalElements").description("전체 데이터 수"),
-                    fieldWithPath("data.totalPages").description("전체 페이지 수"),
-                    fieldWithPath("data.last").description("마지막 페이지 여부"),
-                    fieldWithPath("data.size").description("페이지 크기"),
-                    fieldWithPath("data.number").description("현재 페이지 번호"),
-                    fieldWithPath("data.sort.sorted").description("정렬 여부"),
-                    fieldWithPath("data.sort.unsorted").description("비정렬 여부"),
-                    fieldWithPath("data.sort.empty").description("정렬 정보 비어있음 여부"),
+                    fieldWithPath("data.totalElements").description("전체 개수"),
+                    fieldWithPath("data.totalPages").description("전체 페이지"),
+                    fieldWithPath("data.last").description("마지막 여부"),
+                    fieldWithPath("data.size").description("사이즈"),
+                    fieldWithPath("data.number").description("현재 페이지"),
+                    fieldWithPath("data.sort.sorted").ignored(),
+                    fieldWithPath("data.sort.unsorted").ignored(),
+                    fieldWithPath("data.sort.empty").ignored(),
                     fieldWithPath("data.first").description("첫 페이지 여부"),
-                    fieldWithPath("data.numberOfElements").description("현재 페이지 데이터 수"),
-                    fieldWithPath("data.empty").description("데이터 비어있음 여부")
+                    fieldWithPath("data.numberOfElements").description("현재 페이지 요소 수"),
+                    fieldWithPath("data.empty").description("비어있음 여부")
                 )
             ));
     }
@@ -157,32 +174,24 @@ class NotificationControllerRestDocsTest {
     @Test
     @DisplayName("알림 단건 조회 API 문서화")
     void getNotification() throws Exception {
-        UUID notificationId = UUID.randomUUID();
+        UUID id = UUID.randomUUID();
         NotificationResponse response = NotificationResponse.builder()
-            .id(notificationId)
-            .message("단건 조회 메시지")
-            .status(SendStatus.SUCCESS)
-            .createdAt(LocalDateTime.now())
-            .build();
+            .id(id).message("메시지").status(SendStatus.SUCCESS).createdAt(LocalDateTime.now()).build();
 
-        given(notificationService.getNotification(notificationId)).willReturn(response);
+        given(notificationService.getNotification(id)).willReturn(response);
 
-        mockMvc.perform(get("/api/v1/notifications/{id}", notificationId))
+        mockMvc.perform(get("/api/v1/notifications/{id}", id))
             .andExpect(status().isOk())
             .andDo(document("notifications/get",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(
-                    parameterWithName("id").description("알림 고유 ID")
-                ),
+                pathParameters(parameterWithName("id").description("알림 ID")),
                 responseFields(
                     fieldWithPath("success").description("성공 여부"),
-                    fieldWithPath("data.id").description("알림 ID"),
-                    fieldWithPath("data.message").description("알림 내용"),
-                    fieldWithPath("data.status").description("전송 상태"),
-                    fieldWithPath("data.createdAt").description("생성 시간"),
-                    fieldWithPath("code").description("응답 코드"),
-                    fieldWithPath("message").description("응답 메시지")
+                    fieldWithPath("data.id").description("ID"),
+                    fieldWithPath("data.message").description("내용"),
+                    fieldWithPath("data.status").description("상태"),
+                    fieldWithPath("data.createdAt").description("생성일"),
+                    fieldWithPath("code").description("코드"),
+                    fieldWithPath("message").description("메시지")
                 )
             ));
     }
@@ -190,23 +199,61 @@ class NotificationControllerRestDocsTest {
     @Test
     @DisplayName("알림 삭제 API 문서화")
     void deleteNotification() throws Exception {
-        UUID notificationId = UUID.randomUUID();
-        doNothing().when(notificationService).deleteNotification(eq(notificationId), any());
-
-        mockMvc.perform(delete("/api/v1/notifications/{id}", notificationId)
-                .header("X-User-Id", "ADMIN_USER"))
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(delete("/api/v1/notifications/{id}", id)
+                .header("X-User-Id", "ADMIN"))
             .andExpect(status().isNoContent())
             .andDo(document("notifications/delete",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(
-                    parameterWithName("id").description("삭제할 알림 ID")
-                ),
+                pathParameters(parameterWithName("id").description("ID")),
                 responseFields(
                     fieldWithPath("success").description("성공 여부"),
-                    fieldWithPath("data").description("데이터 없음").optional(),
-                    fieldWithPath("code").description("응답 코드"),
-                    fieldWithPath("message").description("응답 메시지")
+                    fieldWithPath("data").description("데이터 (null)").optional(),
+                    fieldWithPath("code").description("코드"),
+                    fieldWithPath("message").description("메시지")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 실패 - 결과 없음")
+    void getNotifications_Fail_NotFound() throws Exception {
+        given(notificationService.searchNotifications(any(), any()))
+            .willThrow(new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/notifications")
+                .param("slackId", "INVALID_ID"))
+            .andExpect(status().isNotFound())
+            .andDo(document("notifications/list-fail",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부 (false)"),
+                    fieldWithPath("code").description("에러 코드"),
+                    fieldWithPath("message").description("에러 메시지"),
+                    fieldWithPath("data").description("데이터 (null)").optional(),
+                    // .type(JsonFieldType.ARRAY)를 추가하여 타입을 명시
+                    fieldWithPath("errors").type(JsonFieldType.ARRAY).description("상세 에러 목록 (null)").optional()
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 실패 - 슬랙 ID 누락")
+    void getNotifications_Fail_InvalidCondition() throws Exception {
+        mockMvc.perform(get("/api/v1/notifications")
+                // slackId 파라미터를 아예 보내지 않음
+                .param("page", "0")
+                .param("size", "10"))
+            .andExpect(status().isBadRequest()) // Validation 에러로 400 발생
+            .andDo(document("notifications/list-validation-fail",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("success").description("false"),
+                    fieldWithPath("code").description("COMMON_INVALID_INPUT"),
+                    fieldWithPath("message").description("입력값이 올바르지 않습니다."),
+                    fieldWithPath("data").ignored(),
+                    fieldWithPath("errors[].field").description("slackId"),
+                    fieldWithPath("errors[].reason").description("조회할 슬랙 ID는 필수입니다."),
+                    fieldWithPath("errors[].value").description("null")
                 )
             ));
     }

--- a/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
@@ -123,55 +123,112 @@ class NotificationControllerRestDocsTest {
             ));
     }
 
+//    @Test
+//    @DisplayName("알림 목록 조회 API 문서화")
+//    void getNotifications() throws Exception {
+//        NotificationResponse response = NotificationResponse.builder()
+//            .id(UUID.randomUUID()).message("메시지").status(SendStatus.SUCCESS).createdAt(LocalDateTime.now()).build();
+//
+//        given(notificationService.searchNotifications(any(), any()))
+//            .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1));
+//
+//        mockMvc.perform(get("/api/v1/notifications")
+//                .param("slackId", "U12345678")
+//                .param("keyword", "배송") // 검색어 파라미터 추가
+//                .param("page", "0")
+//                .param("size", "10"))
+//            .andExpect(status().isOk())
+//            .andDo(document("notifications/list",
+//                preprocessResponse(prettyPrint()),
+//                queryParameters(
+//                    parameterWithName("slackId").description("슬랙 ID"),
+//                    parameterWithName("keyword").description("메시지 본문 검색어").optional(), // 문서화 누락 보정
+//                    parameterWithName("page").description("페이지").optional(),
+//                    parameterWithName("size").description("사이즈").optional()
+//                ),
+//                responseFields(
+//                    fieldWithPath("success").description("성공 여부"),
+//                    fieldWithPath("code").description("코드"),
+//                    fieldWithPath("message").description("메시지"),
+//                    fieldWithPath("data.content[].id").description("ID"),
+//                    fieldWithPath("data.content[].message").description("내용"),
+//                    fieldWithPath("data.content[].status").description("상태"),
+//                    fieldWithPath("data.content[].createdAt").description("생성일"),
+//                    // 미문서화 에러 해결: 아래 필드들 추가
+//                    fieldWithPath("data.pageable.pageNumber").ignored(),
+//                    fieldWithPath("data.pageable.pageSize").ignored(),
+//                    fieldWithPath("data.pageable.sort.sorted").ignored(),
+//                    fieldWithPath("data.pageable.sort.unsorted").ignored(),
+//                    fieldWithPath("data.pageable.sort.empty").ignored(),
+//                    fieldWithPath("data.pageable.offset").ignored(),
+//                    fieldWithPath("data.pageable.paged").ignored(),
+//                    fieldWithPath("data.pageable.unpaged").ignored(),
+//                    fieldWithPath("data.totalElements").description("전체 개수"),
+//                    fieldWithPath("data.totalPages").description("전체 페이지"),
+//                    fieldWithPath("data.last").description("마지막 여부"),
+//                    fieldWithPath("data.size").description("사이즈"),
+//                    fieldWithPath("data.number").description("현재 페이지"),
+//                    fieldWithPath("data.sort.sorted").ignored(),
+//                    fieldWithPath("data.sort.unsorted").ignored(),
+//                    fieldWithPath("data.sort.empty").ignored(),
+//                    fieldWithPath("data.first").description("첫 페이지 여부"),
+//                    fieldWithPath("data.numberOfElements").description("현재 페이지 요소 수"),
+//                    fieldWithPath("data.empty").description("비어있음 여부")
+//                )
+//            ));
+//    }
+
     @Test
     @DisplayName("알림 목록 조회 API 문서화")
     void getNotifications() throws Exception {
+        // Given: 테스트용 응답 데이터 생성
         NotificationResponse response = NotificationResponse.builder()
-            .id(UUID.randomUUID()).message("메시지").status(SendStatus.SUCCESS).createdAt(LocalDateTime.now()).build();
+            .id(UUID.randomUUID())
+            .message("메시지")
+            .status(SendStatus.SUCCESS)
+            .createdAt(LocalDateTime.now())
+            .build();
 
         given(notificationService.searchNotifications(any(), any()))
             .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1));
 
+        // When & Then
         mockMvc.perform(get("/api/v1/notifications")
                 .param("slackId", "U12345678")
+                .param("keyword", "배송")
                 .param("page", "0")
                 .param("size", "10"))
             .andExpect(status().isOk())
             .andDo(document("notifications/list",
                 preprocessResponse(prettyPrint()),
                 queryParameters(
-                    parameterWithName("slackId").description("슬랙 ID"),
-                    parameterWithName("page").description("페이지").optional(),
-                    parameterWithName("size").description("사이즈").optional()
+                    parameterWithName("slackId").description("수신자 슬랙 ID"),
+                    parameterWithName("keyword").description("메시지 본문 검색 키워드").optional(),
+                    parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+                    parameterWithName("size").description("페이지당 항목 수").optional()
                 ),
-                responseFields(
+                // responseFields 대신 relaxedResponseFields 사용
+                relaxedResponseFields(
                     fieldWithPath("success").description("성공 여부"),
-                    fieldWithPath("code").description("코드"),
-                    fieldWithPath("message").description("메시지"),
-                    fieldWithPath("data.content[].id").description("ID"),
-                    fieldWithPath("data.content[].message").description("내용"),
-                    fieldWithPath("data.content[].status").description("상태"),
-                    fieldWithPath("data.content[].createdAt").description("생성일"),
-                    // 미문서화 에러 해결: 아래 필드들 추가
-                    fieldWithPath("data.pageable.pageNumber").ignored(),
-                    fieldWithPath("data.pageable.pageSize").ignored(),
-                    fieldWithPath("data.pageable.sort.sorted").ignored(),
-                    fieldWithPath("data.pageable.sort.unsorted").ignored(),
-                    fieldWithPath("data.pageable.sort.empty").ignored(),
-                    fieldWithPath("data.pageable.offset").ignored(),
-                    fieldWithPath("data.pageable.paged").ignored(),
-                    fieldWithPath("data.pageable.unpaged").ignored(),
-                    fieldWithPath("data.totalElements").description("전체 개수"),
-                    fieldWithPath("data.totalPages").description("전체 페이지"),
-                    fieldWithPath("data.last").description("마지막 여부"),
-                    fieldWithPath("data.size").description("사이즈"),
-                    fieldWithPath("data.number").description("현재 페이지"),
-                    fieldWithPath("data.sort.sorted").ignored(),
-                    fieldWithPath("data.sort.unsorted").ignored(),
-                    fieldWithPath("data.sort.empty").ignored(),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+
+                    // 데이터 목록 상세
+                    fieldWithPath("data.content[].id").description("알림 ID"),
+                    fieldWithPath("data.content[].message").description("알림 내용"),
+                    fieldWithPath("data.content[].status").description("전송 상태"),
+                    fieldWithPath("data.content[].createdAt").description("생성 일시"),
+
+                    // 페이징 관련 주요 정보 (필요한 것만 선택 기록)
+                    fieldWithPath("data.totalElements").description("전체 데이터 개수"),
+                    fieldWithPath("data.totalPages").description("전체 페이지 수"),
+                    fieldWithPath("data.size").description("페이지 크기"),
+                    fieldWithPath("data.number").description("현재 페이지 번호"),
                     fieldWithPath("data.first").description("첫 페이지 여부"),
-                    fieldWithPath("data.numberOfElements").description("현재 페이지 요소 수"),
-                    fieldWithPath("data.empty").description("비어있음 여부")
+                    fieldWithPath("data.last").description("마지막 페이지 여부"),
+                    fieldWithPath("data.empty").description("결과 비어있음 여부")
+
+                    // pageable.sort, pageable.offset 등은 적지 않아도 에러가 나지 않음!
                 )
             ));
     }
@@ -275,12 +332,14 @@ class NotificationControllerRestDocsTest {
             .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
 
         mockMvc.perform(get("/api/v1/notifications")
-                .param("slackId", "U12345678"))
+                .param("slackId", "U12345678")
+                .param("keyword", "존재하지않는검색어")) // 검색어 시나리오 추가
             .andExpect(status().isOk())
             .andDo(document("notifications/list-empty",
                 preprocessResponse(prettyPrint()),
                 queryParameters(
-                    parameterWithName("slackId").description("조회할 슬랙 ID")
+                    parameterWithName("slackId").description("조회할 슬랙 ID"),
+                    parameterWithName("keyword").description("검색 키워드 (검색 결과가 없는 경우)").optional()
                 ),
                 // relaxedResponseFields를 사용하여 명시한 필드 외에는 검증하지 않음
                 relaxedResponseFields(

--- a/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
@@ -1,0 +1,213 @@
+package com.team.notificationservice.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.notificationservice.application.NotificationRequest;
+import com.team.notificationservice.application.NotificationService;
+import com.team.notificationservice.domain.MsgType;
+import com.team.notificationservice.domain.SendStatus;
+import com.team.notificationservice.presentation.common.GlobalExceptionHandler;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+class NotificationControllerRestDocsTest {
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders.standaloneSetup(new NotificationController(notificationService))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            // Pageable 파라미터를 처리하기 위한 리졸버 등록
+            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+            .apply(documentationConfiguration(restDocumentation))
+            .build();
+    }
+
+    @Test
+    @DisplayName("슬랙 알림 생성 및 발송 API 문서화")
+    void sendNotification() throws Exception {
+        NotificationRequest request = new NotificationRequest(
+            "U12345678", "test@team.com", UUID.randomUUID(), "테스트 알림입니다.", MsgType.ORDER_ALERT
+        );
+
+        mockMvc.perform(post("/api/v1/notifications/slack")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andDo(document("notifications/create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("receiverSlackId").description("수신자 슬랙 ID"),
+                    fieldWithPath("email").description("수신자 이메일").optional(),
+                    fieldWithPath("orderId").description("연관 주문 ID").optional(),
+                    fieldWithPath("message").description("알림 메시지 본문"),
+                    fieldWithPath("msgType").description("메시지 타입")
+                ),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("data").description("응답 데이터").optional(),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 및 검색 API 문서화")
+    void getNotifications() throws Exception {
+        NotificationResponse response = NotificationResponse.builder()
+            .id(UUID.randomUUID())
+            .message("검색된 메시지")
+            .status(SendStatus.SUCCESS)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        given(notificationService.searchNotifications(any(), any()))
+            .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1));
+
+        mockMvc.perform(get("/api/v1/notifications")
+                .param("slackId", "U12345678")
+                .param("keyword", "테스트")
+                .param("page", "0")
+                .param("size", "10"))
+            .andExpect(status().isOk())
+            .andDo(document("notifications/list",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                queryParameters(
+                    parameterWithName("slackId").description("조회 대상 슬랙 ID"),
+                    parameterWithName("keyword").description("검색 키워드").optional(),
+                    parameterWithName("page").description("페이지 번호").optional(),
+                    parameterWithName("size").description("페이지 크기").optional()
+                ),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    // Page 데이터 구조
+                    fieldWithPath("data.content[].id").description("알림 ID"),
+                    fieldWithPath("data.content[].message").description("알림 내용"),
+                    fieldWithPath("data.content[].status").description("전송 상태"),
+                    fieldWithPath("data.content[].createdAt").description("생성 시간"),
+                    // pageable 내부의 모든 필드 명시 또는 무시
+                    fieldWithPath("data.pageable.pageNumber").ignored(),
+                    fieldWithPath("data.pageable.pageSize").ignored(),
+                    fieldWithPath("data.pageable.sort.sorted").ignored(),
+                    fieldWithPath("data.pageable.sort.unsorted").ignored(),
+                    fieldWithPath("data.pageable.sort.empty").ignored(),
+                    fieldWithPath("data.pageable.offset").ignored(),
+                    fieldWithPath("data.pageable.paged").ignored(),
+                    fieldWithPath("data.pageable.unpaged").ignored(),
+                    fieldWithPath("data.totalElements").description("전체 데이터 수"),
+                    fieldWithPath("data.totalPages").description("전체 페이지 수"),
+                    fieldWithPath("data.last").description("마지막 페이지 여부"),
+                    fieldWithPath("data.size").description("페이지 크기"),
+                    fieldWithPath("data.number").description("현재 페이지 번호"),
+                    fieldWithPath("data.sort.sorted").description("정렬 여부"),
+                    fieldWithPath("data.sort.unsorted").description("비정렬 여부"),
+                    fieldWithPath("data.sort.empty").description("정렬 정보 비어있음 여부"),
+                    fieldWithPath("data.first").description("첫 페이지 여부"),
+                    fieldWithPath("data.numberOfElements").description("현재 페이지 데이터 수"),
+                    fieldWithPath("data.empty").description("데이터 비어있음 여부")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("알림 단건 조회 API 문서화")
+    void getNotification() throws Exception {
+        UUID notificationId = UUID.randomUUID();
+        NotificationResponse response = NotificationResponse.builder()
+            .id(notificationId)
+            .message("단건 조회 메시지")
+            .status(SendStatus.SUCCESS)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        given(notificationService.getNotification(notificationId)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/notifications/{id}", notificationId))
+            .andExpect(status().isOk())
+            .andDo(document("notifications/get",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("id").description("알림 고유 ID")
+                ),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("data.id").description("알림 ID"),
+                    fieldWithPath("data.message").description("알림 내용"),
+                    fieldWithPath("data.status").description("전송 상태"),
+                    fieldWithPath("data.createdAt").description("생성 시간"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("알림 삭제 API 문서화")
+    void deleteNotification() throws Exception {
+        UUID notificationId = UUID.randomUUID();
+        doNothing().when(notificationService).deleteNotification(eq(notificationId), any());
+
+        mockMvc.perform(delete("/api/v1/notifications/{id}", notificationId)
+                .header("X-User-Id", "ADMIN_USER"))
+            .andExpect(status().isNoContent())
+            .andDo(document("notifications/delete",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("id").description("삭제할 알림 ID")
+                ),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("data").description("데이터 없음").optional(),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지")
+                )
+            ));
+    }
+}

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -1,60 +1,63 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.13'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.13'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.team'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2025.0.1")
+    set('springCloudVersion', "2025.0.1")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-database-postgresql'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-database-postgresql'
     implementation project(':common')
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
+
+// IntelliJ Kotlin 플러그인 오류 해결을 위한 태스크 등록
+tasks.register("prepareKotlinBuildScriptModel") {}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- DTO 리팩터링: Record 도입
- 에러 처리 체계 고도화: 도메인 직관적인 ErrorCode와 GlobalExceptionHandler 사용 _- 추후 Common에 맞춰 수정 예정_
- API 문서 자동화: Spring RestDocs를 설정하고 주요 API(전송, 조회, 검색, 삭제)에 대한 테스트 코드를 작성하여 최신 명세서를 자동 생성하도록 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #42 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지
- [x] `build/docs/asciidoc/index.html` 생성 및 API 명세 확인 완료

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="356" height="220" alt="스크린샷 2026-03-30 오후 2 25 06" src="https://github.com/user-attachments/assets/62c363b9-fcec-4f52-90a5-2a292e4502ba" />
<img width="1084" height="797" alt="스크린샷 2026-03-30 오후 2 25 45" src="https://github.com/user-attachments/assets/1eb8d2c8-06f1-4405-b6e4-d8f4fc735377" />
<img width="1149" height="505" alt="스크린샷 2026-03-30 오후 2 25 58" src="https://github.com/user-attachments/assets/828b45f1-6394-4923-abea-3a49cca76203" />
<img width="793" height="459" alt="스크린샷 2026-03-30 오후 2 26 07" src="https://github.com/user-attachments/assets/a443cf51-13ec-4980-a754-6579750537ff" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
- [ ] 페이징 응답 시 RestDocs에서 일부 필드를 ignored() 처리했는데, 팀 내에서 페이징 메타데이터 전체를 문서화할지 여부에 대해 의견 부탁드립니다.
- [ ] 나중에 BaseEntity, ApiResponse 등을 공통으로 빼내면 여기에서도 추가 작업이 필요합니다.
## 근데 RestDocs 이렇게 쓰는 거 맞나요?ㅋㅋㅋㅋ ㅠㅠㅠㅠ
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이벤트 기반 비동기 알림 전송 도입, 내부 전송용 엔드포인트 추가 및 API 응답 표준화(ApiResponse, ErrorCode, ServiceException)

* **문서**
  * AsciiDoc 기반 Notification API 명세 추가 및 빌드 시 REST Docs 산출물 패키징

* **테스트**
  * 이벤트 발행 검증 및 컨트롤러 REST Docs 테스트 추가

* **버그 수정**
  * 전역 예외 처리 도입으로 일관된 오류 응답 및 민감값 마스킹

* **개선**
  * 입력 검증 강화 및 DTO/응답 객체 불변화

* **작업(Chore)**
  * 빌드 편의용 빈 태스크 등록 및 패키징 흐름 보완
<!-- end of auto-generated comment: release notes by coderabbit.ai -->