### PR TITLE
Feat/32 공통 에러 응답 구현

### DIFF
--- a/common/src/main/java/com/team/common/config/GlobalExceptionHandlerAutoConfiguration.java
+++ b/common/src/main/java/com/team/common/config/GlobalExceptionHandlerAutoConfiguration.java
@@ -1,0 +1,16 @@
+package com.team.common.config;
+
+import com.team.common.exception.GlobalExceptionHandler;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+public class GlobalExceptionHandlerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GlobalExceptionHandler globalExceptionHandler() {
+        return new GlobalExceptionHandler();
+    }
+}

--- a/common/src/main/java/com/team/common/exception/BusinessException.java
+++ b/common/src/main/java/com/team/common/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package com.team.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/common/src/main/java/com/team/common/exception/CommonErrorCode.java
+++ b/common/src/main/java/com/team/common/exception/CommonErrorCode.java
@@ -1,0 +1,15 @@
+package com.team.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    INVALID_INPUT("INVALID_INPUT", "잘못된 입력값입니다", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/common/src/main/java/com/team/common/exception/CommonErrorCode.java
+++ b/common/src/main/java/com/team/common/exception/CommonErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
-    INVALID_INPUT("INVALID_INPUT", "잘못된 입력값입니다", HttpStatus.BAD_REQUEST);
+    INVALID_INPUT("INVALID_INPUT", "잘못된 입력값입니다", HttpStatus.BAD_REQUEST),
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/common/src/main/java/com/team/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/team/common/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.team.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String getCode();
+
+    String getMessage();
+
+    HttpStatus getStatus();
+}

--- a/common/src/main/java/com/team/common/exception/ErrorResponse.java
+++ b/common/src/main/java/com/team/common/exception/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.team.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+    private Object details;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, Object details) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), details);
+    }
+}

--- a/common/src/main/java/com/team/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/team/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.team.common.exception;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        return ResponseEntity.status(e.getErrorCode().getStatus()).body(ErrorResponse.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        List<Map<String, String>> details = e.getBindingResult().getFieldErrors().stream().map(
+            error -> Map.of("field", error.getField(), "value",
+                error.getRejectedValue() != null ? String.valueOf(error.getRejectedValue()) : "", "reason",
+                String.valueOf(error.getDefaultMessage()))).toList();
+
+        return ResponseEntity.status(CommonErrorCode.INVALID_INPUT.getStatus())
+            .body(ErrorResponse.of(CommonErrorCode.INVALID_INPUT, details));
+    }
+
+}

--- a/common/src/main/java/com/team/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/team/common/exception/GlobalExceptionHandler.java
@@ -20,10 +20,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
-        List<Map<String, String>> details = e.getBindingResult().getFieldErrors().stream().map(
-            error -> Map.of("field", error.getField(), "value",
-                error.getRejectedValue() != null ? String.valueOf(error.getRejectedValue()) : "", "reason",
-                String.valueOf(error.getDefaultMessage()))).toList();
+        List<Map<String, String>> details = e.getBindingResult().getFieldErrors().stream()
+            .map(error -> Map.of("field", error.getField(), "reason", String.valueOf(error.getDefaultMessage())))
+            .toList();
 
         return ResponseEntity.status(CommonErrorCode.INVALID_INPUT.getStatus())
             .body(ErrorResponse.of(CommonErrorCode.INVALID_INPUT, details));

--- a/common/src/main/java/com/team/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/team/common/exception/GlobalExceptionHandler.java
@@ -2,13 +2,14 @@ package com.team.common.exception;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -26,6 +27,13 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(CommonErrorCode.INVALID_INPUT.getStatus())
             .body(ErrorResponse.of(CommonErrorCode.INVALID_INPUT, details));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected error occurred", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse.of(CommonErrorCode.INTERNAL_SERVER_ERROR));
     }
 
 }

--- a/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.team.common.exception.GlobalExceptionHandler

--- a/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-com.team.common.exception.GlobalExceptionHandler
+com.team.common.config.GlobalExceptionHandlerAutoConfiguration

--- a/product-service/src/main/java/com/team/product_service/ProductServiceApplication.java
+++ b/product-service/src/main/java/com/team/product_service/ProductServiceApplication.java
@@ -1,7 +1,9 @@
 package com.team.product_service;
 
+import com.team.common.exception.GlobalExceptionHandler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing

--- a/product-service/src/main/java/com/team/product_service/ProductServiceApplication.java
+++ b/product-service/src/main/java/com/team/product_service/ProductServiceApplication.java
@@ -1,9 +1,7 @@
 package com.team.product_service;
 
-import com.team.common.exception.GlobalExceptionHandler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing

--- a/product-service/src/main/java/com/team/product_service/global/SecurityConfig.java
+++ b/product-service/src/main/java/com/team/product_service/global/SecurityConfig.java
@@ -1,0 +1,20 @@
+package com.team.product_service.global;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/product-service/src/main/java/com/team/product_service/global/exception/ProductErrorCode.java
+++ b/product-service/src/main/java/com/team/product_service/global/exception/ProductErrorCode.java
@@ -1,0 +1,18 @@
+package com.team.product_service.global.exception;
+
+import com.team.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+    PRODUCT_NOT_FOUND("PRODUCT_NOT_FOUND", "상품을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    DUPLICATE_PRODUCT("DUPLICATE_PRODUCT", "이미 존재하는 상품입니다", HttpStatus.CONFLICT),
+    PRODUCT_DELETED("PRODUCT_DELETED", "삭제된 상품입니다", HttpStatus.GONE);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/product-service/src/main/java/com/team/product_service/product/presentation/ProductController.java
+++ b/product-service/src/main/java/com/team/product_service/product/presentation/ProductController.java
@@ -1,4 +1,28 @@
 package com.team.product_service.product.presentation;
 
+import com.team.common.exception.BusinessException;
+import com.team.product_service.product.domain.Product;
+import com.team.product_service.product.domain.ProductRepository;
+import com.team.product_service.global.exception.ProductErrorCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
 public class ProductController {
+
+    private final ProductRepository productRepository;
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<Product> commonErrorTest(@PathVariable UUID productId) {
+        return productRepository.findById(productId)
+                .map(ResponseEntity::ok)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
 }

--- a/product-service/src/main/java/com/team/product_service/product/presentation/ProductController.java
+++ b/product-service/src/main/java/com/team/product_service/product/presentation/ProductController.java
@@ -1,14 +1,6 @@
 package com.team.product_service.product.presentation;
 
-import com.team.common.exception.BusinessException;
-import com.team.product_service.product.domain.Product;
-import com.team.product_service.product.domain.ProductRepository;
-import com.team.product_service.global.exception.ProductErrorCode;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,12 +9,4 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ProductController {
 
-    private final ProductRepository productRepository;
-
-    @GetMapping("/{productId}")
-    public ResponseEntity<Product> commonErrorTest(@PathVariable UUID productId) {
-        return productRepository.findById(productId)
-                .map(ResponseEntity::ok)
-                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
-    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- ErrorCode, ErrorResponse, BusinessException, GlobalExceptionHandler, CommonErrorCode 구현
- GlobalExceptionHandler AutoConfiguration 등록
- ProductErrorCode, SecurityConfig(임시 전체 허용)

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #32 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
<img width="1738" height="734" alt="image" src="https://github.com/user-attachments/assets/3addd3ff-555a-45c4-90cb-00855bfbbb85" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

- 공통 에러(CommonErrorCode)는 common 모듈에서 관리하고 서비스별 에러 코드(ProductErrorCode 등)는 각 서비스에서 관리하도록 설계했습니다.
- error response에서 rejected Value 삭제했습니다.
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * 중앙화된 예외 처리 시스템 도입으로 일관된 오류 응답 제공
  * 입력 검증 실패 시 상세한 오류 정보 반환
  * 제품 조회 REST API 추가

* **Chores**
  * Spring Security 설정 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->