### PR TITLE
Refactor/67 noti-common-sql - Common 적용, DB스키마 수정

### DIFF
--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -31,6 +31,7 @@ ext {
 }
 
 dependencies {
+    implementation project(':common')
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -45,6 +46,9 @@ dependencies {
     implementation 'com.slack.api:slack-api-client:1.38.0' //슬랙
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
+
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationEventListener.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationEventListener.java
@@ -5,8 +5,6 @@ import com.team.notificationservice.infrastructure.SlackClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -20,7 +18,6 @@ public class NotificationEventListener {
     // private final KafkaTemplate<String, NotificationCreatedEvent> kafkaTemplate; // TODO: Kafka 도입 시 주입 예정
 
     // 알림 생성 이벤트를 처리 TransactionPhase.AFTER_COMMIT: 메인 비즈니스 로직이 DB에 완전히 커밋된 후 실행됨
-    @Transactional(propagation = Propagation.REQUIRES_NEW) // 별도의 트랜잭션에서 전송 결과(성공/실패)를 기록함
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleNotificationCreatedEvent(NotificationCreatedEvent event) {
         log.info("이벤트 수신 - 알림 전송 시작: ID={}", event.notificationId());

--- a/notification-service/src/main/java/com/team/notificationservice/domain/Notification.java
+++ b/notification-service/src/main/java/com/team/notificationservice/domain/Notification.java
@@ -1,5 +1,9 @@
 package com.team.notificationservice.domain;
 
+
+import com.team.common.BaseEntity;
+import com.team.notificationservice.presentation.common.ErrorCode;
+import com.team.notificationservice.presentation.common.ServiceException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -27,17 +31,25 @@ public class Notification extends BaseEntity {
     private UUID id;
 
     private UUID receiverId;
+
+    @Column(nullable = false, length = 100)
     private String receiverSlackId;
+
     private UUID orderId;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MsgType msgType;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String msgContent;
 
     @Enumerated(EnumType.STRING)
-    private SendStatus sendStatus;
+    @Column(nullable = false)
+    @Builder.Default
+    private SendStatus sendStatus = SendStatus.PENDING;
+
+    private UUID refId;
 
     public void markAsSuccess() {
         this.sendStatus = SendStatus.SUCCESS;
@@ -48,7 +60,13 @@ public class Notification extends BaseEntity {
     }
 
     public void delete(String adminId) {
-        super.delete(adminId);
-//        this.sendStatus = SendStatus.CANCEL;
+        try {
+            // adminId가 유효한 UUID 형식인지 확인 후 부모 메서드 호출
+            super.softDelete(UUID.fromString(adminId));
+            //this.sendStatus = SendStatus.CANCEL;
+        } catch (IllegalArgumentException | NullPointerException e) {
+            // UUID 형식이 아닐 경우에 대한 에러 처리
+            throw new ServiceException(ErrorCode.COMMON_INVALID_USER_ID);
+        }
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/infrastructure/SlackClient.java
+++ b/notification-service/src/main/java/com/team/notificationservice/infrastructure/SlackClient.java
@@ -17,7 +17,6 @@ public class SlackClient {
 
     // 1. 이메일로 슬랙 ID(U...) 찾기
     public String findSlackIdByEmail(String email) {
-        log.info("현재 사용 중인 토큰: {}", slackToken); // 토큰이 xoxb-로 시작하는지 확인
         try {
             MethodsClient client = Slack.getInstance().methods(slackToken);
             UsersLookupByEmailResponse response = client.usersLookupByEmail(r -> r.email(email));

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ErrorCode.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ErrorCode.java
@@ -6,14 +6,15 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorCode {
+public enum ErrorCode implements com.team.common.exception.ErrorCode {
 
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_INVALID_TOKEN", "인증 토큰이 유효하지 않습니다."),
     SERVER_CONFIG_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_CONFIG_MISSING", "서버 설정 정보가 누락되었습니다."),
-    
+
     // 공통 에러
     COMMON_INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "입력값이 올바르지 않습니다."),
     COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
+    COMMON_INVALID_USER_ID(HttpStatus.BAD_REQUEST, "COMMON_INVALID_USER_ID", "입력된 유저 아이디가 올바르지 않은 형식입니다."),
 
     // 알림 서비스 전용 에러
     NOTI_RECIPIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI_RECIPIENT_NOT_FOUND", "알림 수신 대상자(슬랙 ID 또는 이메일)를 찾을 수 없습니다."),
@@ -23,4 +24,19 @@ public enum ErrorCode {
     private final HttpStatus status;
     private final String code;
     private final String message;
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/NotificationExceptionHandler.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/NotificationExceptionHandler.java
@@ -4,6 +4,8 @@ import com.team.notificationservice.presentation.common.ApiResponse.ValidationEr
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
@@ -13,7 +15,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class NotificationExceptionHandler {
 
     @ExceptionHandler(ServiceException.class)
     public ResponseEntity<ApiResponse<Void>> handleServiceException(ServiceException e) {

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
@@ -1,38 +1,39 @@
 package com.team.notificationservice.presentation.common;
 
+import com.team.common.exception.BusinessException;
 import java.util.List;
+import lombok.Getter;
 
-public class ServiceException extends RuntimeException {
+public class ServiceException extends BusinessException {
     private final ErrorCode errorCode;
     // 상세 에러 정보를 담을 리스트 추가
+    @Getter
     private final List<ApiResponse.ValidationError> errors;
 
     // 기존 생성자 (상세 에러가 없는 경우)
     public ServiceException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
+        super(errorCode);
         this.errorCode = errorCode;
         this.errors = null;
     }
 
     // 새로운 생성자 (상세 에러가 있는 경우)
     public ServiceException(ErrorCode errorCode, List<ApiResponse.ValidationError> errors) {
-        super(errorCode.getMessage());
+        super(errorCode);
         this.errorCode = errorCode;
         this.errors = errors;
     }
 
     // 원인 보존을 위한 생성자 추가
     public ServiceException(ErrorCode errorCode, Throwable cause) {
-        super(errorCode.getMessage(), cause);
+        super(errorCode);
         this.errorCode = errorCode;
         this.errors = null;
     }
 
+    @Override
     public ErrorCode getErrorCode() {
         return errorCode;
     }
 
-    public List<ApiResponse.ValidationError> getErrors() {
-        return errors;
-    }
 }

--- a/notification-service/src/main/resources/db/migration/V1__init.sql
+++ b/notification-service/src/main/resources/db/migration/V1__init.sql
@@ -1,34 +1,47 @@
 /* =========================================================
-   NOTIFICATION-SERVICE : V1__init.sql
-   - p_notification 생성
-   주의:
-   - 타 서비스(order)에는 물리 FK를 걸지 않음 (Logical FK)
+   [NOTIFICATION-SERVICE]
+   Table: p_notification
    ========================================================= */
 
--- =========================================================
--- TABLE: p_notification
--- =========================================================
-CREATE TABLE p_notification
-(
-    id                UUID PRIMARY KEY,
-    order_id          UUID,   -- logical FK -> p_order.id
-    receiver_id       UUID, -- logical FK -> p_user.id
-    receiver_slack_id VARCHAR(255),
-    msg_type          VARCHAR(50) NOT NULL,
-    msg_content       TEXT        NOT NULL,
-    send_status       VARCHAR(50) NOT NULL,
-    created_at        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    created_by        VARCHAR(255),
-    updated_at        TIMESTAMP WITH TIME ZONE,
-    updated_by        VARCHAR(255),
-    deleted_at        TIMESTAMP WITH TIME ZONE,
-    deleted_by        VARCHAR(255)
+-- 1. ENUM 타입 생성 (메시지 유형 및 전송 상태)
+CREATE TYPE notification_msg_type AS ENUM (
+    'ORDER_ALERT',
+    'DAILY_REPORT'
 );
 
--- =========================================================
--- CONSTRAINT / INDEX
--- =========================================================
--- 알림 조회 시 성능을 위해 인덱스 추가 (특히 삭제되지 않은 데이터 조회용)
-CREATE INDEX idx_notification_order_id ON p_notification (order_id);
-CREATE INDEX idx_notification_receiver_slack_id ON p_notification (receiver_slack_id);
-CREATE INDEX idx_notification_deleted_at ON p_notification (deleted_at);
+CREATE TYPE notification_send_status AS ENUM (
+    'PENDING',
+    'SUCCESS',
+    'FAIL'
+);
+
+-- 2. TABLE 생성
+CREATE TABLE p_notification
+(
+    -- 기본 키
+    id                UUID PRIMARY KEY,
+
+    -- 비즈니스 로직 필드
+    receiver_id       UUID,                              -- logical FK -> p_user.id
+    receiver_slack_id VARCHAR(100)             NOT NULL,
+    order_id          UUID,                              -- logical FK -> p_order.id
+    msg_type          notification_msg_type    NOT NULL,
+    msg_content       TEXT                     NOT NULL,
+    send_status       notification_send_status NOT NULL DEFAULT 'PENDING',
+    ref_id            UUID,                              -- 참조 ID (추가된 필드)
+
+    -- common.BaseEntity 상속 필드 (Audit)
+    created_at        TIMESTAMP                NOT NULL DEFAULT NOW(),
+    created_by        UUID                     NOT NULL,
+    updated_at        TIMESTAMP,
+    updated_by        UUID,
+    deleted_at        TIMESTAMP,
+    deleted_by        UUID
+);
+
+-- 3. INDEX 설정 (조회 성능 최적화)
+CREATE INDEX idx_p_notification_receiver_id ON p_notification (receiver_id);
+CREATE INDEX idx_p_notification_order_id ON p_notification (order_id);
+CREATE INDEX idx_p_notification_msg_type ON p_notification (msg_type);
+CREATE INDEX idx_p_notification_send_status ON p_notification (send_status);
+CREATE INDEX idx_p_notification_deleted_at ON p_notification (deleted_at);

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
@@ -35,7 +35,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+    "spring.config.import=optional:file:../application-common.properties,optional:file:../application-secret.properties"
+})
 @RecordApplicationEvents
 class NotificationServiceApplicationTests {
 
@@ -171,15 +173,19 @@ class NotificationServiceApplicationTests {
     void deleteNotificationTest() {
         // given
         UUID id = UUID.randomUUID();
+        // 테스트용 유효한 UUID 문자열 생성
+        String validAdminId = UUID.randomUUID().toString();
+
         Notification mockNoti = Notification.builder().msgContent("삭제").build();
         when(notificationRepository.findByIdAndDeletedAtIsNull(id)).thenReturn(Optional.of(mockNoti));
 
         // when
-        notificationService.deleteNotification(id, "user-123");
+        // "user-123" 대신 UUID 형식인 validAdminId를 전달
+        notificationService.deleteNotification(id, validAdminId);
 
         // then
         assertNotNull(mockNoti.getDeletedAt());
-        assertEquals("user-123", mockNoti.getDeletedBy());
-        verify(notificationRepository, times(1)).save(mockNoti); // save 호출 여부 확인 추가
+        assertEquals(validAdminId, mockNoti.getDeletedBy().toString());
+        verify(notificationRepository, times(1)).save(mockNoti);
     }
 }

--- a/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
@@ -28,7 +28,7 @@ import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationService;
 import com.team.notificationservice.domain.MsgType;
 import com.team.notificationservice.domain.SendStatus;
-import com.team.notificationservice.presentation.common.GlobalExceptionHandler;
+import com.team.notificationservice.presentation.common.NotificationExceptionHandler;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -65,7 +65,7 @@ class NotificationControllerRestDocsTest {
         notificationController = new NotificationController(notificationService);
 
         mockMvc = MockMvcBuilders.standaloneSetup(notificationController) // 필드에 담긴 인스턴스를 사용해야 함
-            .setControllerAdvice(new GlobalExceptionHandler())
+            .setControllerAdvice(new NotificationExceptionHandler())
             .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
             .apply(documentationConfiguration(restDocumentation))
             .build();


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
1. 인프라 및 의존성 설정
* 공통 모듈 통합: implementation project(':common')을 추가하여 공통 예외 처리 및 엔티티 규격을 적용
* 테스트 환경 강화: Testcontainers (PostgreSQL) 의존성을 추가하여 로컬 및 CI 환경에서 실제 DB 컨테이너를 이용한 테스트 기반을 마련

2. 도메인 및 비즈니스 로직 고도화
* Notification 엔티티 개선:
  - 각 필드에 nullable = false 제약 조건 / 기본값 적용 / 타입검증로직 추가
* 이벤트 리스너 최적화: NotificationEventListener에서 불필요한 트랜잭션 전파 설정 제거

3. 예외 처리 및 공통 규격 적용
* 커스텀 예외 핸들러: GlobalExceptionHandler를 NotificationExceptionHandler로 변경, 알림 서비스 전용 예외가 우선 처리되도록 설정
* ErrorCode 확장: common 모듈의 인터페이스를 구현하고, COMMON_INVALID_USER_ID 등 신규 에러 코드 정의

4. DB 스키마 및 테스트 코드
* Flyway V1 수정: VARCHAR로 관리하던 메시지 유형과 전송 상태를 PostgreSQL ENUM 타입으로 변경하고, 주요 조회 조건 컬럼에 인덱스를 추가
* 테스트 케이스 현행화:
  * NotificationServiceApplicationTests에서 외부 설정 파일(application-secret.properties 등)을 로드하도록 수정
  * 테스트 시 사용하던 하드코딩된 문자열을 유효한 UUID 형식으로 교체


## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #67 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="418" height="344" alt="스크린샷 2026-04-01 오후 7 28 03" src="https://github.com/user-attachments/assets/9696840e-e6a5-4a22-a43a-9706f9aa3522" />
<img width="418" height="320" alt="스크린샷 2026-04-01 오후 7 28 19" src="https://github.com/user-attachments/assets/922bb852-fe31-43c9-9fd9-13cea1bbba58" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 ID 삭제 시 입력값 검증 강화
  * 잘못된 사용자 ID 입력에 대한 명확한 오류 메시지 추가

* **개선사항**
  * 알림 데이터 필드의 데이터 무결성 제약 조건 강화
  * 데이터베이스 스키마 최적화로 데이터 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->