### PR TITLE
Feat/73 delivery 외부/내부 api 분리

### DIFF
--- a/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/service/DeliveryService.java
@@ -1,29 +1,45 @@
 package com.team.deliveryservice.delivery.application.service;
 
-import com.team.deliveryservice.delivery.application.search.DeliverySearchCondition;
-import com.team.deliveryservice.delivery.application.dto.request.*;
+import com.team.deliveryservice.delivery.application.dto.request.AssignCompanyDeliveryManagerRequest;
+import com.team.deliveryservice.delivery.application.dto.request.AssignHubDeliveryManagerRequest;
+import com.team.deliveryservice.delivery.application.dto.request.ChangeDeliveryStatusRequest;
+import com.team.deliveryservice.delivery.application.dto.request.CreateDeliveryRequest;
+import com.team.deliveryservice.delivery.application.dto.request.UpdateDeliveryRequest;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryPageResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryResponse;
+import com.team.deliveryservice.delivery.application.search.DeliverySearchCondition;
 import com.team.deliveryservice.global.common.CurrentUser;
 import java.util.UUID;
 
 public interface DeliveryService {
 
-    DeliveryResponse createDelivery(CreateDeliveryRequest request, CurrentUser currentUser);
-
+    // external
     DeliveryResponse getDelivery(UUID deliveryId, CurrentUser currentUser);
 
     DeliveryPageResponse searchDeliveries(DeliverySearchCondition condition, CurrentUser currentUser);
 
     DeliveryResponse updateDelivery(UUID deliveryId, UpdateDeliveryRequest request, CurrentUser currentUser);
 
-    DeliveryResponse changeDeliveryStatus(UUID deliveryId, ChangeDeliveryStatusRequest request, CurrentUser currentUser);
+    DeliveryResponse assignCompanyDeliveryManager(
+        UUID deliveryId,
+        AssignCompanyDeliveryManagerRequest request,
+        CurrentUser currentUser
+    );
 
-    DeliveryResponse cancelDelivery(UUID deliveryId, CurrentUser currentUser);
+    DeliveryResponse assignHubDeliveryManager(
+        UUID deliveryId,
+        AssignHubDeliveryManagerRequest request,
+        CurrentUser currentUser
+    );
 
-    DeliveryResponse assignCompanyDeliveryManager(UUID deliveryId, AssignCompanyDeliveryManagerRequest request, CurrentUser currentUser);
+    // internal
+    DeliveryResponse createDelivery(CreateDeliveryRequest request);
 
-    DeliveryResponse assignHubDeliveryManager(UUID deliveryId, AssignHubDeliveryManagerRequest request, CurrentUser currentUser);
+    DeliveryResponse getDelivery(UUID deliveryId);
 
-    void deleteDelivery(UUID deliveryId, CurrentUser currentUser);
+    DeliveryResponse changeDeliveryStatus(UUID deliveryId, ChangeDeliveryStatusRequest request);
+
+    DeliveryResponse cancelDelivery(UUID deliveryId);
+
+    void deleteDelivery(UUID deliveryId);
 }

--- a/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/service/DeliveryServiceImpl.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/service/DeliveryServiceImpl.java
@@ -36,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryServiceImpl implements DeliveryService {
 
     private static final String DELIVERY_ORDER_ID_UNIQUE_CONSTRAINT = "uk_p_delivery_order_id_active";
+    private static final UUID SYSTEM_ACTOR_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
 
     private final DeliveryRepository deliveryRepository;
     private final DeliveryManagerRepository deliveryManagerRepository;
@@ -43,7 +44,7 @@ public class DeliveryServiceImpl implements DeliveryService {
 
     @Override
     @Transactional
-    public DeliveryResponse createDelivery(CreateDeliveryRequest request, CurrentUser currentUser) {
+    public DeliveryResponse createDelivery(CreateDeliveryRequest request) {
         if (deliveryRepository.existsByOrderIdAndDeletedAtIsNull(request.orderId())) {
             throw new ServiceException(DeliveryErrorCode.DELIVERY_ALREADY_EXISTS);
         }
@@ -72,10 +73,14 @@ public class DeliveryServiceImpl implements DeliveryService {
     }
 
     @Override
-    public DeliveryResponse getDelivery(UUID deliveryId, CurrentUser currentUser) {
-        Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
-            .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+    public DeliveryResponse getDelivery(UUID deliveryId) {
+        Delivery delivery = getDeliveryEntity(deliveryId);
+        return DeliveryResponse.from(delivery, getRouteLogs(deliveryId));
+    }
 
+    @Override
+    public DeliveryResponse getDelivery(UUID deliveryId, CurrentUser currentUser) {
+        Delivery delivery = getDeliveryEntity(deliveryId);
         return DeliveryResponse.from(delivery, getRouteLogs(deliveryId));
     }
 
@@ -114,8 +119,7 @@ public class DeliveryServiceImpl implements DeliveryService {
     @Override
     @Transactional
     public DeliveryResponse updateDelivery(UUID deliveryId, UpdateDeliveryRequest request, CurrentUser currentUser) {
-        Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
-            .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+        Delivery delivery = getDeliveryEntity(deliveryId);
 
         delivery.updateInfo(
             request.deliveryAddress(),
@@ -129,13 +133,8 @@ public class DeliveryServiceImpl implements DeliveryService {
 
     @Override
     @Transactional
-    public DeliveryResponse changeDeliveryStatus(
-        UUID deliveryId,
-        ChangeDeliveryStatusRequest request,
-        CurrentUser currentUser
-    ) {
-        Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
-            .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+    public DeliveryResponse changeDeliveryStatus(UUID deliveryId, ChangeDeliveryStatusRequest request) {
+        Delivery delivery = getDeliveryEntity(deliveryId);
 
         try {
             delivery.updateStatus(request.deliveryStatus());
@@ -148,9 +147,8 @@ public class DeliveryServiceImpl implements DeliveryService {
 
     @Override
     @Transactional
-    public DeliveryResponse cancelDelivery(UUID deliveryId, CurrentUser currentUser) {
-        Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
-            .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+    public DeliveryResponse cancelDelivery(UUID deliveryId) {
+        Delivery delivery = getDeliveryEntity(deliveryId);
 
         try {
             delivery.cancel();
@@ -168,8 +166,7 @@ public class DeliveryServiceImpl implements DeliveryService {
         AssignCompanyDeliveryManagerRequest request,
         CurrentUser currentUser
     ) {
-        Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
-            .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+        Delivery delivery = getDeliveryEntity(deliveryId);
 
         DeliveryManager manager = deliveryManagerRepository.findByIdAndDeletedAtIsNull(request.deliveryManagerId())
             .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_MANAGER_NOT_FOUND));
@@ -198,8 +195,7 @@ public class DeliveryServiceImpl implements DeliveryService {
         AssignHubDeliveryManagerRequest request,
         CurrentUser currentUser
     ) {
-        Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
-            .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+        Delivery delivery = getDeliveryEntity(deliveryId);
 
         DeliveryRouteLog routeLog = getRouteLog(request.routeLogId());
 
@@ -225,16 +221,19 @@ public class DeliveryServiceImpl implements DeliveryService {
 
     @Override
     @Transactional
-    public void deleteDelivery(UUID deliveryId, CurrentUser currentUser) {
-        Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
-            .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
-
-        delivery.softDelete(currentUser.userId());
+    public void deleteDelivery(UUID deliveryId) {
+        Delivery delivery = getDeliveryEntity(deliveryId);
+        delivery.softDelete(SYSTEM_ACTOR_ID);
 
         List<DeliveryRouteLog> routeLogs =
             deliveryRouteLogRepository.findAllByDeliveryIdAndDeletedAtIsNullOrderBySequenceNoAsc(deliveryId);
 
-        routeLogs.forEach(routeLog -> routeLog.softDelete(currentUser.userId()));
+        routeLogs.forEach(routeLog -> routeLog.softDelete(SYSTEM_ACTOR_ID));
+    }
+
+    private Delivery getDeliveryEntity(UUID deliveryId) {
+        return deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
+            .orElseThrow(() -> new ServiceException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
     }
 
     private List<DeliveryRouteLogResponse> getRouteLogs(UUID deliveryId) {

--- a/delivery-service/src/main/java/com/team/deliveryservice/delivery/presentation/ExternalDeliveryController.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/delivery/presentation/ExternalDeliveryController.java
@@ -2,38 +2,25 @@ package com.team.deliveryservice.delivery.presentation;
 
 import com.team.deliveryservice.delivery.application.dto.request.AssignCompanyDeliveryManagerRequest;
 import com.team.deliveryservice.delivery.application.dto.request.AssignHubDeliveryManagerRequest;
-import com.team.deliveryservice.delivery.application.dto.request.ChangeDeliveryStatusRequest;
-import com.team.deliveryservice.delivery.application.dto.request.CreateDeliveryRequest;
+import com.team.deliveryservice.delivery.application.dto.request.UpdateDeliveryRequest;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryPageResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryResponse;
 import com.team.deliveryservice.delivery.application.search.DeliverySearchCondition;
 import com.team.deliveryservice.delivery.application.service.DeliveryService;
-import com.team.deliveryservice.delivery.application.dto.request.UpdateDeliveryRequest;
 import com.team.deliveryservice.global.common.ApiResponse;
 import com.team.deliveryservice.global.common.CurrentUser;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/deliveries")
-public class DeliveryController {
+public class ExternalDeliveryController {
 
     private final DeliveryService deliveryService;
-
-    @PostMapping
-    public ResponseEntity<ApiResponse<DeliveryResponse>> create(
-        @Valid @RequestBody CreateDeliveryRequest request,
-        CurrentUser currentUser
-    ) {
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(ApiResponse.ok(deliveryService.createDelivery(request, currentUser)));
-    }
 
     @GetMapping("/{deliveryId}")
     public ResponseEntity<ApiResponse<DeliveryResponse>> get(
@@ -66,27 +53,6 @@ public class DeliveryController {
         ));
     }
 
-    @PatchMapping("/{deliveryId}/status")
-    public ResponseEntity<ApiResponse<DeliveryResponse>> changeStatus(
-        @PathVariable UUID deliveryId,
-        @Valid @RequestBody ChangeDeliveryStatusRequest request,
-        CurrentUser currentUser
-    ) {
-        return ResponseEntity.ok(ApiResponse.ok(
-            deliveryService.changeDeliveryStatus(deliveryId, request, currentUser)
-        ));
-    }
-
-    @PatchMapping("/{deliveryId}/cancel")
-    public ResponseEntity<ApiResponse<DeliveryResponse>> cancel(
-        @PathVariable UUID deliveryId,
-        CurrentUser currentUser
-    ) {
-        return ResponseEntity.ok(ApiResponse.ok(
-            deliveryService.cancelDelivery(deliveryId, currentUser)
-        ));
-    }
-
     @PatchMapping("/{deliveryId}/assign-company-manager")
     public ResponseEntity<ApiResponse<DeliveryResponse>> assignCompanyManager(
         @PathVariable UUID deliveryId,
@@ -107,14 +73,5 @@ public class DeliveryController {
         return ResponseEntity.ok(ApiResponse.ok(
             deliveryService.assignHubDeliveryManager(deliveryId, request, currentUser)
         ));
-    }
-
-    @DeleteMapping("/{deliveryId}")
-    public ResponseEntity<ApiResponse<Void>> delete(
-        @PathVariable UUID deliveryId,
-        CurrentUser currentUser
-    ) {
-        deliveryService.deleteDelivery(deliveryId, currentUser);
-        return ResponseEntity.ok(ApiResponse.ok());
     }
 }

--- a/delivery-service/src/main/java/com/team/deliveryservice/delivery/presentation/InternalDeliveryController.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/delivery/presentation/InternalDeliveryController.java
@@ -1,0 +1,66 @@
+package com.team.deliveryservice.delivery.presentation;
+
+import com.team.deliveryservice.delivery.application.dto.request.ChangeDeliveryStatusRequest;
+import com.team.deliveryservice.delivery.application.dto.request.CreateDeliveryRequest;
+import com.team.deliveryservice.delivery.application.dto.response.DeliveryResponse;
+import com.team.deliveryservice.delivery.application.service.DeliveryService;
+import com.team.deliveryservice.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/deliveries")
+public class InternalDeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<DeliveryResponse>> create(
+        @Valid @RequestBody CreateDeliveryRequest request
+    ) {
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.ok(deliveryService.createDelivery(request)));
+    }
+
+    @GetMapping("/{deliveryId}")
+    public ResponseEntity<ApiResponse<DeliveryResponse>> get(
+        @PathVariable UUID deliveryId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+            deliveryService.getDelivery(deliveryId)
+        ));
+    }
+
+    @PatchMapping("/{deliveryId}/status")
+    public ResponseEntity<ApiResponse<DeliveryResponse>> changeStatus(
+        @PathVariable UUID deliveryId,
+        @Valid @RequestBody ChangeDeliveryStatusRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+            deliveryService.changeDeliveryStatus(deliveryId, request)
+        ));
+    }
+
+    @PatchMapping("/{deliveryId}/cancel")
+    public ResponseEntity<ApiResponse<DeliveryResponse>> cancel(
+        @PathVariable UUID deliveryId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+            deliveryService.cancelDelivery(deliveryId)
+        ));
+    }
+
+    @DeleteMapping("/{deliveryId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+        @PathVariable UUID deliveryId
+    ) {
+        deliveryService.deleteDelivery(deliveryId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+}

--- a/delivery-service/src/test/java/com/team/deliveryservice/application/delivery/DeliveryServiceImplTest.java
+++ b/delivery-service/src/test/java/com/team/deliveryservice/application/delivery/DeliveryServiceImplTest.java
@@ -38,6 +38,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DeliveryServiceImplTest {
 
+    private static final UUID SYSTEM_ACTOR_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
     @Mock
     private DeliveryRepository deliveryRepository;
 
@@ -65,12 +67,10 @@ class DeliveryServiceImplTest {
             LocalDateTime.of(2026, 4, 1, 18, 0)
         );
 
-        CurrentUser currentUser = new CurrentUser(UUID.randomUUID(), "MASTER_ADMIN", null, null);
-
         given(deliveryRepository.existsByOrderIdAndDeletedAtIsNull(request.orderId())).willReturn(false);
         given(deliveryRepository.save(any(Delivery.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-        DeliveryResponse response = deliveryService.createDelivery(request, currentUser);
+        DeliveryResponse response = deliveryService.createDelivery(request);
 
         assertThat(response.orderId()).isEqualTo(request.orderId());
         assertThat(response.deliveryAddress()).isEqualTo(request.deliveryAddress());
@@ -95,11 +95,9 @@ class DeliveryServiceImplTest {
             LocalDateTime.of(2026, 4, 1, 18, 0)
         );
 
-        CurrentUser currentUser = new CurrentUser(UUID.randomUUID(), "MASTER_ADMIN", null, null);
-
         given(deliveryRepository.existsByOrderIdAndDeletedAtIsNull(orderId)).willReturn(true);
 
-        assertThatThrownBy(() -> deliveryService.createDelivery(request, currentUser))
+        assertThatThrownBy(() -> deliveryService.createDelivery(request))
             .isInstanceOf(ServiceException.class)
             .hasMessage(DeliveryErrorCode.DELIVERY_ALREADY_EXISTS.getMessage());
     }
@@ -108,7 +106,6 @@ class DeliveryServiceImplTest {
     @DisplayName("배송 상태 변경 성공 - WAITING_AT_HUB 에서 MOVING_BETWEEN_HUBS 로 변경")
     void change_delivery_status_success() {
         UUID deliveryId = UUID.randomUUID();
-        CurrentUser currentUser = new CurrentUser(UUID.randomUUID(), "MASTER_ADMIN", null, null);
 
         Delivery delivery = createDelivery();
         ChangeDeliveryStatusRequest request = new ChangeDeliveryStatusRequest(
@@ -119,7 +116,7 @@ class DeliveryServiceImplTest {
         given(deliveryRouteLogRepository.findAllByDeliveryIdAndDeletedAtIsNullOrderBySequenceNoAsc(deliveryId))
             .willReturn(List.of());
 
-        DeliveryResponse response = deliveryService.changeDeliveryStatus(deliveryId, request, currentUser);
+        DeliveryResponse response = deliveryService.changeDeliveryStatus(deliveryId, request);
 
         assertThat(response.deliveryStatus()).isEqualTo(DeliveryStatus.MOVING_BETWEEN_HUBS);
         assertThat(delivery.getStartedAt()).isNotNull();
@@ -129,7 +126,6 @@ class DeliveryServiceImplTest {
     @DisplayName("배송 상태 변경 실패 - 허용되지 않은 상태 전이")
     void change_delivery_status_fail_invalid_transition() {
         UUID deliveryId = UUID.randomUUID();
-        CurrentUser currentUser = new CurrentUser(UUID.randomUUID(), "MASTER_ADMIN", null, null);
 
         Delivery delivery = createDelivery();
         ChangeDeliveryStatusRequest request = new ChangeDeliveryStatusRequest(
@@ -138,7 +134,7 @@ class DeliveryServiceImplTest {
 
         given(deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)).willReturn(Optional.of(delivery));
 
-        assertThatThrownBy(() -> deliveryService.changeDeliveryStatus(deliveryId, request, currentUser))
+        assertThatThrownBy(() -> deliveryService.changeDeliveryStatus(deliveryId, request))
             .isInstanceOf(ServiceException.class)
             .hasMessage(DeliveryErrorCode.DELIVERY_STATUS_CHANGE_NOT_ALLOWED.getMessage());
     }
@@ -147,7 +143,6 @@ class DeliveryServiceImplTest {
     @DisplayName("배송 취소 성공 - WAITING_AT_HUB 상태에서만 가능")
     void cancel_delivery_success() {
         UUID deliveryId = UUID.randomUUID();
-        CurrentUser currentUser = new CurrentUser(UUID.randomUUID(), "COMPANY_MANAGER", null, null);
 
         Delivery delivery = createDelivery();
 
@@ -155,7 +150,7 @@ class DeliveryServiceImplTest {
         given(deliveryRouteLogRepository.findAllByDeliveryIdAndDeletedAtIsNullOrderBySequenceNoAsc(deliveryId))
             .willReturn(List.of());
 
-        DeliveryResponse response = deliveryService.cancelDelivery(deliveryId, currentUser);
+        DeliveryResponse response = deliveryService.cancelDelivery(deliveryId);
 
         assertThat(response.deliveryStatus()).isEqualTo(DeliveryStatus.CANCELLED);
     }
@@ -164,14 +159,13 @@ class DeliveryServiceImplTest {
     @DisplayName("배송 취소 실패 - WAITING_AT_HUB 이외 상태에서는 불가")
     void cancel_delivery_fail_when_not_waiting() {
         UUID deliveryId = UUID.randomUUID();
-        CurrentUser currentUser = new CurrentUser(UUID.randomUUID(), "COMPANY_MANAGER", null, null);
 
         Delivery delivery = createDelivery();
         delivery.updateStatus(DeliveryStatus.MOVING_BETWEEN_HUBS);
 
         given(deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)).willReturn(Optional.of(delivery));
 
-        assertThatThrownBy(() -> deliveryService.cancelDelivery(deliveryId, currentUser))
+        assertThatThrownBy(() -> deliveryService.cancelDelivery(deliveryId))
             .isInstanceOf(ServiceException.class)
             .hasMessage(DeliveryErrorCode.DELIVERY_CANCEL_NOT_ALLOWED.getMessage());
     }
@@ -468,9 +462,6 @@ class DeliveryServiceImplTest {
     @DisplayName("배송 삭제 시 배송 경로 로그도 함께 soft delete")
     void delete_delivery_soft_delete_route_logs() {
         UUID deliveryId = UUID.randomUUID();
-        UUID userId = UUID.randomUUID();
-
-        CurrentUser currentUser = new CurrentUser(userId, "MASTER_ADMIN", null, null);
 
         Delivery delivery = createDelivery();
 
@@ -488,12 +479,12 @@ class DeliveryServiceImplTest {
         given(deliveryRouteLogRepository.findAllByDeliveryIdAndDeletedAtIsNullOrderBySequenceNoAsc(deliveryId))
             .willReturn(List.of(routeLog));
 
-        deliveryService.deleteDelivery(deliveryId, currentUser);
+        deliveryService.deleteDelivery(deliveryId);
 
         assertThat(delivery.getDeletedAt()).isNotNull();
-        assertThat(delivery.getDeletedBy()).isEqualTo(userId);
+        assertThat(delivery.getDeletedBy()).isEqualTo(SYSTEM_ACTOR_ID);
         assertThat(routeLog.getDeletedAt()).isNotNull();
-        assertThat(routeLog.getDeletedBy()).isEqualTo(userId);
+        assertThat(routeLog.getDeletedBy()).isEqualTo(SYSTEM_ACTOR_ID);
     }
 
     private Delivery createDelivery() {

--- a/delivery-service/src/test/java/com/team/deliveryservice/presentation/delivery/ExternalDeliveryControllerRestDocsTest.java
+++ b/delivery-service/src/test/java/com/team/deliveryservice/presentation/delivery/ExternalDeliveryControllerRestDocsTest.java
@@ -126,48 +126,6 @@ class ExternalDeliveryControllerRestDocsTest {
     }
 
     @Test
-    @DisplayName("배송 생성 API 문서화")
-    void createDeliveryDocs() throws Exception {
-        CreateDeliveryRequest request = new CreateDeliveryRequest(
-            UUID.fromString("20000000-0000-0000-0000-000000000001"),
-            UUID.fromString("40000000-0000-0000-0000-000000000001"),
-            UUID.fromString("40000000-0000-0000-0000-000000000002"),
-            UUID.fromString("60000000-0000-0000-0000-000000000001"),
-            "서울시 강남구 테헤란로 123",
-            "101호",
-            "홍길동",
-            "U12345678",
-            LocalDateTime.of(2026, 4, 1, 18, 0)
-        );
-
-        when(deliveryService.createDelivery(any(), any())).thenReturn(mockDeliveryResponse());
-
-        mockMvc.perform(withCurrentUser(
-                post("/api/v1/deliveries")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            ))
-            .andExpect(status().isCreated())
-            .andDo(document("deliveries/create",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                requestFields(
-                    fieldWithPath("orderId").type(JsonFieldType.STRING).description("주문 ID"),
-                    fieldWithPath("originHubId").type(JsonFieldType.STRING).description("출발 허브 ID"),
-                    fieldWithPath("destinationHubId").type(JsonFieldType.STRING).description("도착 허브 ID"),
-                    fieldWithPath("receiverCompanyId").type(JsonFieldType.STRING).description("수령 업체 ID"),
-                    fieldWithPath("deliveryAddress").type(JsonFieldType.STRING).description("배송 주소"),
-                    fieldWithPath("deliveryAddressDetail").type(JsonFieldType.STRING).optional().description("배송 상세 주소"),
-                    fieldWithPath("recipientName").type(JsonFieldType.STRING).description("수령인 이름"),
-                    fieldWithPath("recipientSlackId").type(JsonFieldType.STRING).description("수령인 슬랙 ID"),
-                    fieldWithPath("companyDeliveryManagerId").type(JsonFieldType.STRING).optional().description("업체 배송 담당자 ID"),
-                    fieldWithPath("finalDispatchDeadlineAt").type(JsonFieldType.STRING).optional().description("최종 출고 마감 시각")
-                ),
-                commonDeliveryResponseFields()
-            ));
-    }
-
-    @Test
     @DisplayName("배송 단건 조회 API 문서화")
     void getDeliveryDocs() throws Exception {
         UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
@@ -310,54 +268,6 @@ class ExternalDeliveryControllerRestDocsTest {
     }
 
     @Test
-    @DisplayName("배송 상태 변경 API 문서화")
-    void changeStatusDocs() throws Exception {
-        UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
-        ChangeDeliveryStatusRequest request = new ChangeDeliveryStatusRequest(DeliveryStatus.MOVING_BETWEEN_HUBS);
-
-        when(deliveryService.changeDeliveryStatus(eq(deliveryId), any(), any())).thenReturn(mockDeliveryResponse());
-
-        mockMvc.perform(withCurrentUser(
-                patch("/api/v1/deliveries/{deliveryId}/status", deliveryId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            ))
-            .andExpect(status().isOk())
-            .andDo(document("deliveries/change-status",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(
-                    parameterWithName("deliveryId").description("배송 ID")
-                ),
-                requestFields(
-                    fieldWithPath("deliveryStatus").type(JsonFieldType.STRING).description("변경할 배송 상태")
-                ),
-                commonDeliveryResponseFields()
-            ));
-    }
-
-    @Test
-    @DisplayName("배송 취소 API 문서화")
-    void cancelDeliveryDocs() throws Exception {
-        UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
-
-        when(deliveryService.cancelDelivery(eq(deliveryId), any())).thenReturn(mockDeliveryResponse());
-
-        mockMvc.perform(withCurrentUser(
-                patch("/api/v1/deliveries/{deliveryId}/cancel", deliveryId)
-            ))
-            .andExpect(status().isOk())
-            .andDo(document("deliveries/cancel",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(
-                    parameterWithName("deliveryId").description("배송 ID")
-                ),
-                commonDeliveryResponseFields()
-            ));
-    }
-
-    @Test
     @DisplayName("업체 배송 담당자 배정 API 문서화")
     void assignCompanyManagerDocs() throws Exception {
         UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
@@ -419,31 +329,6 @@ class ExternalDeliveryControllerRestDocsTest {
             ));
     }
 
-    @Test
-    @DisplayName("배송 삭제 API 문서화")
-    void deleteDeliveryDocs() throws Exception {
-        UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
-
-        doNothing().when(deliveryService).deleteDelivery(eq(deliveryId), any());
-
-        mockMvc.perform(withCurrentUser(
-                delete("/api/v1/deliveries/{deliveryId}", deliveryId)
-            ))
-            .andExpect(status().isOk())
-            .andDo(document("deliveries/delete",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(
-                    parameterWithName("deliveryId").description("배송 ID")
-                ),
-                responseFields(
-                    fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
-                    fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터"),
-                    fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
-                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
-                )
-            ));
-    }
 
     private org.springframework.restdocs.payload.ResponseFieldsSnippet commonDeliveryResponseFields() {
         return responseFields(

--- a/delivery-service/src/test/java/com/team/deliveryservice/presentation/delivery/ExternalDeliveryControllerRestDocsTest.java
+++ b/delivery-service/src/test/java/com/team/deliveryservice/presentation/delivery/ExternalDeliveryControllerRestDocsTest.java
@@ -33,7 +33,7 @@ import com.team.deliveryservice.delivery.application.service.DeliveryService;
 import com.team.deliveryservice.delivery.application.dto.request.UpdateDeliveryRequest;
 import com.team.deliveryservice.delivery.domain.DeliveryRouteStatus;
 import com.team.deliveryservice.delivery.domain.DeliveryStatus;
-import com.team.deliveryservice.delivery.presentation.DeliveryController;
+import com.team.deliveryservice.delivery.presentation.ExternalDeliveryController;
 import com.team.deliveryservice.global.config.CurrentUserArgumentResolver;
 import com.team.deliveryservice.global.config.CurrentUserResolverConfig;
 import java.math.BigDecimal;
@@ -55,7 +55,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@WebMvcTest(DeliveryController.class)
+@WebMvcTest(ExternalDeliveryController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs(outputDir = "build/generated-snippets")
 @AutoConfigureObservability
@@ -69,7 +69,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
     "spring.docker.compose.enabled=false",
     "management.tracing.enabled=false"
 })
-class DeliveryControllerRestDocsTest {
+class ExternalDeliveryControllerRestDocsTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/delivery-service/src/test/java/com/team/deliveryservice/presentation/delivery/InternalDeliveryControllerRestDocsTest.java
+++ b/delivery-service/src/test/java/com/team/deliveryservice/presentation/delivery/InternalDeliveryControllerRestDocsTest.java
@@ -1,0 +1,271 @@
+package com.team.deliveryservice.presentation.delivery;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.deliveryservice.delivery.application.dto.request.ChangeDeliveryStatusRequest;
+import com.team.deliveryservice.delivery.application.dto.request.CreateDeliveryRequest;
+import com.team.deliveryservice.delivery.application.dto.response.DeliveryResponse;
+import com.team.deliveryservice.delivery.application.dto.response.DeliveryRouteLogResponse;
+import com.team.deliveryservice.delivery.application.service.DeliveryService;
+import com.team.deliveryservice.delivery.domain.DeliveryRouteStatus;
+import com.team.deliveryservice.delivery.domain.DeliveryStatus;
+import com.team.deliveryservice.delivery.presentation.InternalDeliveryController;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(InternalDeliveryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs(outputDir = "build/generated-snippets")
+@AutoConfigureObservability
+@TestPropertySource(properties = {
+    "spring.cloud.discovery.enabled=false",
+    "eureka.client.enabled=false",
+    "spring.docker.compose.enabled=false",
+    "management.tracing.enabled=false"
+})
+class InternalDeliveryControllerRestDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private DeliveryService deliveryService;
+
+    private DeliveryRouteLogResponse mockRouteLogResponse() {
+        return DeliveryRouteLogResponse.builder()
+            .routeLogId(UUID.fromString("30000000-0000-0000-0000-000000000001"))
+            .sequenceNo(1)
+            .departureHubId(UUID.fromString("40000000-0000-0000-0000-000000000001"))
+            .arrivalHubId(UUID.fromString("40000000-0000-0000-0000-000000000002"))
+            .expectedDistanceKm(new BigDecimal("12.50"))
+            .expectedDurationMinutes(30)
+            .routeStatus(DeliveryRouteStatus.WAITING_AT_HUB)
+            .deliveryManagerId(UUID.fromString("50000000-0000-0000-0000-000000000001"))
+            .departedAt(null)
+            .arrivedAt(null)
+            .build();
+    }
+
+    private DeliveryResponse mockDeliveryResponse() {
+        return DeliveryResponse.builder()
+            .deliveryId(UUID.fromString("10000000-0000-0000-0000-000000000001"))
+            .orderId(UUID.fromString("20000000-0000-0000-0000-000000000001"))
+            .deliveryStatus(DeliveryStatus.WAITING_AT_HUB)
+            .originHubId(UUID.fromString("40000000-0000-0000-0000-000000000001"))
+            .destinationHubId(UUID.fromString("40000000-0000-0000-0000-000000000002"))
+            .receiverCompanyId(UUID.fromString("60000000-0000-0000-0000-000000000001"))
+            .deliveryAddress("서울시 강남구 테헤란로 123")
+            .deliveryAddressDetail("101호")
+            .recipientName("홍길동")
+            .recipientSlackId("U12345678")
+            .companyDeliveryManagerId(UUID.fromString("50000000-0000-0000-0000-000000000001"))
+            .startedAt(null)
+            .completedAt(null)
+            .finalDispatchDeadlineAt(LocalDateTime.of(2026, 4, 1, 18, 0))
+            .createdAt(LocalDateTime.of(2026, 3, 31, 10, 0))
+            .updatedAt(null)
+            .routeLogs(List.of(mockRouteLogResponse()))
+            .build();
+    }
+
+    @Test
+    @DisplayName("내부 배송 생성 API 문서화")
+    void createDeliveryDocs() throws Exception {
+        CreateDeliveryRequest request = new CreateDeliveryRequest(
+            UUID.fromString("20000000-0000-0000-0000-000000000001"),
+            UUID.fromString("40000000-0000-0000-0000-000000000001"),
+            UUID.fromString("40000000-0000-0000-0000-000000000002"),
+            UUID.fromString("60000000-0000-0000-0000-000000000001"),
+            "서울시 강남구 테헤란로 123",
+            "101호",
+            "홍길동",
+            "U12345678",
+            LocalDateTime.of(2026, 4, 1, 18, 0)
+        );
+
+        when(deliveryService.createDelivery(any())).thenReturn(mockDeliveryResponse());
+
+        mockMvc.perform(
+                post("/internal/v1/deliveries")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+            .andExpect(status().isCreated())
+            .andDo(document("internal-deliveries/create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("orderId").type(JsonFieldType.STRING).description("주문 ID"),
+                    fieldWithPath("originHubId").type(JsonFieldType.STRING).description("출발 허브 ID"),
+                    fieldWithPath("destinationHubId").type(JsonFieldType.STRING).description("도착 허브 ID"),
+                    fieldWithPath("receiverCompanyId").type(JsonFieldType.STRING).description("수령 업체 ID"),
+                    fieldWithPath("deliveryAddress").type(JsonFieldType.STRING).description("배송 주소"),
+                    fieldWithPath("deliveryAddressDetail").type(JsonFieldType.STRING).optional().description("배송 상세 주소"),
+                    fieldWithPath("recipientName").type(JsonFieldType.STRING).description("수령인 이름"),
+                    fieldWithPath("recipientSlackId").type(JsonFieldType.STRING).description("수령인 슬랙 ID"),
+                    fieldWithPath("finalDispatchDeadlineAt").type(JsonFieldType.STRING).optional().description("최종 출고 마감 시각")
+                ),
+                commonDeliveryResponseFields()
+            ));
+    }
+
+    @Test
+    @DisplayName("내부 배송 단건 조회 API 문서화")
+    void getDeliveryDocs() throws Exception {
+        UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+
+        when(deliveryService.getDelivery(eq(deliveryId))).thenReturn(mockDeliveryResponse());
+
+        mockMvc.perform(get("/internal/v1/deliveries/{deliveryId}", deliveryId))
+            .andExpect(status().isOk())
+            .andDo(document("internal-deliveries/get",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("deliveryId").description("배송 ID")
+                ),
+                commonDeliveryResponseFields()
+            ));
+    }
+
+    @Test
+    @DisplayName("내부 배송 상태 변경 API 문서화")
+    void changeStatusDocs() throws Exception {
+        UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+        ChangeDeliveryStatusRequest request = new ChangeDeliveryStatusRequest(DeliveryStatus.MOVING_BETWEEN_HUBS);
+
+        when(deliveryService.changeDeliveryStatus(eq(deliveryId), any())).thenReturn(mockDeliveryResponse());
+
+        mockMvc.perform(
+                patch("/internal/v1/deliveries/{deliveryId}/status", deliveryId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+            .andExpect(status().isOk())
+            .andDo(document("internal-deliveries/change-status",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("deliveryId").description("배송 ID")
+                ),
+                requestFields(
+                    fieldWithPath("deliveryStatus").type(JsonFieldType.STRING).description("변경할 배송 상태")
+                ),
+                commonDeliveryResponseFields()
+            ));
+    }
+
+    @Test
+    @DisplayName("내부 배송 취소 API 문서화")
+    void cancelDeliveryDocs() throws Exception {
+        UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+
+        when(deliveryService.cancelDelivery(eq(deliveryId))).thenReturn(mockDeliveryResponse());
+
+        mockMvc.perform(patch("/internal/v1/deliveries/{deliveryId}/cancel", deliveryId))
+            .andExpect(status().isOk())
+            .andDo(document("internal-deliveries/cancel",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("deliveryId").description("배송 ID")
+                ),
+                commonDeliveryResponseFields()
+            ));
+    }
+
+    @Test
+    @DisplayName("내부 배송 삭제 API 문서화")
+    void deleteDeliveryDocs() throws Exception {
+        UUID deliveryId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+
+        doNothing().when(deliveryService).deleteDelivery(eq(deliveryId));
+
+        mockMvc.perform(delete("/internal/v1/deliveries/{deliveryId}", deliveryId))
+            .andExpect(status().isOk())
+            .andDo(document("internal-deliveries/delete",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("deliveryId").description("배송 ID")
+                ),
+                responseFields(
+                    fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터"),
+                    fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                )
+            ));
+    }
+
+    private org.springframework.restdocs.payload.ResponseFieldsSnippet commonDeliveryResponseFields() {
+        return responseFields(
+            fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+            fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+            fieldWithPath("data.deliveryId").type(JsonFieldType.STRING).description("배송 ID"),
+            fieldWithPath("data.orderId").type(JsonFieldType.STRING).description("주문 ID"),
+            fieldWithPath("data.deliveryStatus").type(JsonFieldType.STRING).description("배송 상태"),
+            fieldWithPath("data.originHubId").type(JsonFieldType.STRING).description("출발 허브 ID"),
+            fieldWithPath("data.destinationHubId").type(JsonFieldType.STRING).description("도착 허브 ID"),
+            fieldWithPath("data.receiverCompanyId").type(JsonFieldType.STRING).description("수령 업체 ID"),
+            fieldWithPath("data.deliveryAddress").type(JsonFieldType.STRING).description("배송 주소"),
+            fieldWithPath("data.deliveryAddressDetail").type(JsonFieldType.STRING).optional().description("배송 상세 주소"),
+            fieldWithPath("data.recipientName").type(JsonFieldType.STRING).description("수령인 이름"),
+            fieldWithPath("data.recipientSlackId").type(JsonFieldType.STRING).description("수령인 슬랙 ID"),
+            fieldWithPath("data.companyDeliveryManagerId").type(JsonFieldType.STRING).optional().description("업체 배송 담당자 ID"),
+            fieldWithPath("data.startedAt").type(JsonFieldType.NULL).optional().description("배송 시작 시각"),
+            fieldWithPath("data.completedAt").type(JsonFieldType.NULL).optional().description("배송 완료 시각"),
+            fieldWithPath("data.finalDispatchDeadlineAt").type(JsonFieldType.STRING).optional().description("최종 출고 마감 시각"),
+            fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("생성 시각"),
+            fieldWithPath("data.updatedAt").type(JsonFieldType.NULL).optional().description("수정 시각"),
+            fieldWithPath("data.routeLogs").type(JsonFieldType.ARRAY).description("배송 경로 로그 목록"),
+            fieldWithPath("data.routeLogs[].routeLogId").type(JsonFieldType.STRING).description("배송 경로 로그 ID"),
+            fieldWithPath("data.routeLogs[].sequenceNo").type(JsonFieldType.NUMBER).description("경로 순번"),
+            fieldWithPath("data.routeLogs[].departureHubId").type(JsonFieldType.STRING).description("출발 허브 ID"),
+            fieldWithPath("data.routeLogs[].arrivalHubId").type(JsonFieldType.STRING).description("도착 허브 ID"),
+            fieldWithPath("data.routeLogs[].expectedDistanceKm").type(JsonFieldType.NUMBER).description("예상 거리(km)"),
+            fieldWithPath("data.routeLogs[].expectedDurationMinutes").type(JsonFieldType.NUMBER).description("예상 소요 시간(분)"),
+            fieldWithPath("data.routeLogs[].routeStatus").type(JsonFieldType.STRING).description("배송 경로 상태"),
+            fieldWithPath("data.routeLogs[].deliveryManagerId").type(JsonFieldType.STRING).optional().description("허브 배송 담당자 ID"),
+            fieldWithPath("data.routeLogs[].departedAt").type(JsonFieldType.NULL).optional().description("출발 시각"),
+            fieldWithPath("data.routeLogs[].arrivedAt").type(JsonFieldType.NULL).optional().description("도착 시각"),
+            fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+            fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 배송 API를 외부 컨트롤러와 내부 컨트롤러로 분리하고, 이에 맞춰 테스트 구조를 정리

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #73 

기존 배송 컨트롤러에 섞여 있던 외부/내부 API를 분리.
외부 API는 조회, 검색, 수정, 담당자 배정만 담당하고, 내부 API는 생성, 내부조회, 상태변경, 취소, 삭제를 담당하도록 재구성.

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="1118" height="225" alt="스크린샷 2026-04-03 오전 3 02 38" src="https://github.com/user-attachments/assets/ebcd326f-ae14-466f-aa15-5d9ff437403b" />

<img width="1400" height="797" alt="스크린샷 2026-04-03 오전 2 59 53" src="https://github.com/user-attachments/assets/f465bf78-75e8-4546-9bad-e8fd4b5ac776" />
<img width="855" height="488" alt="스크린샷 2026-04-03 오전 3 00 00" src="https://github.com/user-attachments/assets/330f1d50-2a7d-44bd-beb6-f773bd100e62" />
<img width="802" height="483" alt="스크린샷 2026-04-03 오전 3 00 05" src="https://github.com/user-attachments/assets/b15f2bad-37da-4417-8f92-65263de1d795" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **리팩토링**
  * 배송 관리 API의 내부 구조를 개선하여 내부 및 외부 엔드포인트를 명확하게 분리했습니다. 배송 생성, 조회, 상태 변경, 취소, 삭제 등의 작업이 더욱 효율적으로 처리됩니다.

* **테스트**
  * 리팩토링된 API 구조에 맞춘 새로운 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->