### PR TITLE
Refactor/96 Hub 공통 페이징 유틸리티 적용 및 전역 예외 처리 통합

### DIFF
--- a/common/src/main/java/com/team/common/page/PageResponse.java
+++ b/common/src/main/java/com/team/common/page/PageResponse.java
@@ -1,0 +1,28 @@
+package com.team.common.page;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+    List<T> content,
+    PageInfo pageInfo
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+            page.getContent(),
+            new PageInfo(
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+            )
+        );
+    }
+
+    public record PageInfo(
+        int currentPage,
+        int size,
+        long totalElements,
+        int totalPages
+    ) {}
+}

--- a/hub-server/src/main/java/com/team/hubservice/global/exception/HubErrorCode.java
+++ b/hub-server/src/main/java/com/team/hubservice/global/exception/HubErrorCode.java
@@ -1,0 +1,18 @@
+package com.team.hubservice.global.exception;
+
+import com.team.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum HubErrorCode implements ErrorCode {
+    HUB_ALREADY_EXISTS("HUB_ALREADY_EXISTS", "이미 동일한 이름의 허브가 존재합니다.", HttpStatus.CONFLICT),
+    HUB_NOT_FOUND("HUB_NOT_FOUND", "요청한 허브 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}
+

--- a/hub-server/src/main/java/com/team/hubservice/global/exception/HubRouteErrorCode.java
+++ b/hub-server/src/main/java/com/team/hubservice/global/exception/HubRouteErrorCode.java
@@ -1,4 +1,4 @@
-package com.team.hubservice.hubroute.exception;
+package com.team.hubservice.global.exception;
 
 import com.team.common.exception.ErrorCode;
 import lombok.Getter;

--- a/hub-server/src/main/java/com/team/hubservice/hub/application/HubService.java
+++ b/hub-server/src/main/java/com/team/hubservice/hub/application/HubService.java
@@ -1,5 +1,7 @@
 package com.team.hubservice.hub.application;
 
+import com.team.common.exception.BusinessException;
+import com.team.hubservice.global.exception.HubErrorCode;
 import com.team.hubservice.hub.domain.Hub;
 import com.team.hubservice.hub.domain.HubRepository;
 import java.util.UUID;
@@ -23,7 +25,7 @@ public class HubService {
     @Transactional
     public HubResult createHub(HubCreateCommand command) {
         if (hubRepository.existsByName(command.name())) {
-            throw new IllegalArgumentException("이미 동일한 이름의 허브가 존재합니다.");
+            throw new BusinessException(HubErrorCode.HUB_ALREADY_EXISTS);
         }
 
         Hub hub = Hub.create(
@@ -70,7 +72,7 @@ public class HubService {
 
     private Hub findHubById(UUID hubId) {
         return hubRepository.findById(hubId)
-                .orElseThrow(() -> new IllegalArgumentException("요청한 허브 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
     }
 
     private void checkActiveRoutesAndCompanies(UUID hubId) {

--- a/hub-server/src/main/java/com/team/hubservice/hub/presentation/HubController.java
+++ b/hub-server/src/main/java/com/team/hubservice/hub/presentation/HubController.java
@@ -1,9 +1,11 @@
 package com.team.hubservice.hub.presentation;
 
+import com.team.common.page.PageResponse;
 import com.team.hubservice.hub.application.HubCreateCommand;
 import com.team.hubservice.hub.application.HubResult;
 import com.team.hubservice.hub.application.HubService;
 import com.team.hubservice.hub.application.HubUpdateCommand;
+import com.team.common.page.PageSizeUtils;
 import com.team.hubservice.hub.presentation.dto.HubCreateRequest;
 import com.team.hubservice.hub.presentation.dto.HubResponse;
 import com.team.hubservice.hub.presentation.dto.HubUpdateRequest;
@@ -59,28 +61,18 @@ public class HubController {
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Map<String, Object>> getHubs(
-            @RequestParam(required = false) String name,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size) {
+        @RequestParam(required = false) String name,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size) {
 
-        int validSize = (size == 10 || size == 30 || size == 50) ? size : 10;
+        int validSize = PageSizeUtils.normalize(size);
 
         Pageable pageable = PageRequest.of(Math.max(0, page - 1), validSize);
         Page<HubResult> resultPage = hubService.getHubs(name, pageable);
 
         Page<HubResponse> hubPage = resultPage.map(HubResponse::from);
 
-        Map<String, Object> pageInfo = new HashMap<>();
-        pageInfo.put("currentPage", hubPage.getNumber() + 1);
-        pageInfo.put("size", hubPage.getSize());
-        pageInfo.put("totalElements", hubPage.getTotalElements());
-        pageInfo.put("totalPages", hubPage.getTotalPages());
-
-        Map<String, Object> data = new HashMap<>();
-        data.put("content", hubPage.getContent());
-        data.put("pageInfo", pageInfo);
-
-        return buildResponse(HttpStatus.OK.value(), "허브 목록 조회를 성공했습니다.", data);
+        return buildResponse(HttpStatus.OK.value(), "허브 목록 조회를 성공했습니다.", PageResponse.from(hubPage));
     }
 
     @GetMapping("/{hubId}")

--- a/hub-server/src/main/java/com/team/hubservice/hubroute/application/HubRouteOptimalService.java
+++ b/hub-server/src/main/java/com/team/hubservice/hubroute/application/HubRouteOptimalService.java
@@ -3,7 +3,7 @@ package com.team.hubservice.hubroute.application;
 import com.team.common.exception.BusinessException;
 import com.team.hubservice.hubroute.domain.HubRoute;
 import com.team.hubservice.hubroute.domain.HubRouteRepository;
-import com.team.hubservice.hubroute.exception.HubRouteErrorCode;
+import com.team.hubservice.global.exception.HubRouteErrorCode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;

--- a/hub-server/src/main/java/com/team/hubservice/hubroute/application/HubRouteService.java
+++ b/hub-server/src/main/java/com/team/hubservice/hubroute/application/HubRouteService.java
@@ -3,7 +3,7 @@ package com.team.hubservice.hubroute.application;
 import com.team.common.exception.BusinessException;
 import com.team.hubservice.hubroute.domain.HubRoute;
 import com.team.hubservice.hubroute.domain.HubRouteRepository;
-import com.team.hubservice.hubroute.exception.HubRouteErrorCode;
+import com.team.hubservice.global.exception.HubRouteErrorCode;
 import java.util.UUID;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;

--- a/hub-server/src/main/java/com/team/hubservice/hubroute/domain/HubRoute.java
+++ b/hub-server/src/main/java/com/team/hubservice/hubroute/domain/HubRoute.java
@@ -2,7 +2,7 @@ package com.team.hubservice.hubroute.domain;
 
 import com.team.common.BaseEntity;
 import com.team.common.exception.BusinessException;
-import com.team.hubservice.hubroute.exception.HubRouteErrorCode;
+import com.team.hubservice.global.exception.HubRouteErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/hub-server/src/main/java/com/team/hubservice/hubroute/presentation/HubRouteController.java
+++ b/hub-server/src/main/java/com/team/hubservice/hubroute/presentation/HubRouteController.java
@@ -1,9 +1,11 @@
 package com.team.hubservice.hubroute.presentation;
 
+import com.team.common.page.PageResponse;
 import com.team.hubservice.hubroute.application.HubRouteCreateCommand;
 import com.team.hubservice.hubroute.application.HubRouteResult;
 import com.team.hubservice.hubroute.application.HubRouteService;
 import com.team.hubservice.hubroute.application.HubRouteUpdateCommand;
+import com.team.common.page.PageSizeUtils;
 import com.team.hubservice.hubroute.presentation.dto.HubRouteCreateRequest;
 import com.team.hubservice.hubroute.presentation.dto.HubRouteResponse;
 import com.team.hubservice.hubroute.presentation.dto.HubRouteUpdateRequest;
@@ -55,23 +57,13 @@ public class HubRouteController {
         @RequestParam(defaultValue = "1") int page,
         @RequestParam(defaultValue = "10") int size) {
 
-        int validSize = (size == 10 || size == 30 || size == 50) ? size : 10;
+        int validSize = PageSizeUtils.normalize(size);
         Pageable pageable = PageRequest.of(Math.max(0, page - 1), validSize);
 
         Page<HubRouteResult> resultPage = hubRouteService.getHubRoutes(departureHubId, pageable);
         Page<HubRouteResponse> routePage = resultPage.map(HubRouteResponse::from);
 
-        Map<String, Object> pageInfo = new HashMap<>();
-        pageInfo.put("currentPage", routePage.getNumber() + 1);
-        pageInfo.put("size", routePage.getSize());
-        pageInfo.put("totalElements", routePage.getTotalElements());
-        pageInfo.put("totalPages", routePage.getTotalPages());
-
-        Map<String, Object> data = new HashMap<>();
-        data.put("content", routePage.getContent());
-        data.put("pageInfo", pageInfo);
-
-        return buildResponse(HttpStatus.OK.value(), "허브 이동 경로 목록 조회를 성공했습니다.", data);
+        return buildResponse(HttpStatus.OK.value(), "허브 이동 경로 목록 조회를 성공했습니다.", PageResponse.from(routePage));
     }
 
     @PatchMapping("/{routeId}")


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- common 모듈의 page 패키지 하위에 데이터 목록과 페이지 정보를 한 번에 조립해 반환하는 PageResponse 레코드 클래스 도입 및 적용
- 컨트롤러 내부에 하드코딩되어 있던 페이지 사이즈 검증 로직을 common 모듈의 PageSizeUtils로 전면 교체하여 코드 중복 제거
- 서비스 계층에서 개별적으로 발생시키던 IllegalArgumentException 등의 예외를 BusinessException으로 전환
- BusinessException 전환을 통해 common 모듈의 GlobalExceptionHandler가 일관된 포맷으로 에러 응답을 처리하도록 구조 개선
- 에러 코드 관리를 중앙 집중화하기 위해 패키지 구조 변경 

## 🚀 주요 변경 사항
> Related to: #96

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="742" height="124" alt="image" src="https://github.com/user-attachments/assets/f5cce6a3-f735-4dc2-b9d0-3bc0ce3ec09d" />
<img width="2208" height="774" alt="image" src="https://github.com/user-attachments/assets/308a77e3-7346-4a82-9484-8348ee0f9e8b" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - 컨트롤러에서 페이징 객체를 조립하던 로직을 공통 모듈에 추가했습니다. 
<br>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 페이지네이션 응답 형식 표준화로 일관된 데이터 구조 제공
  * 허브 관련 작업에서 명확한 오류 메시지 추가 (중복, 미존재 등)

* **개선 사항**
  * 페이지 크기 검증 로직 통합으로 일관성 향상
  * 전역 오류 코드 관리 체계 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->