### PR TITLE
refactor/101- common 페이징 규격 통합 및 알림 서비스 리팩토링

### DIFF
--- a/common/src/main/java/com/team/common/ApiResponse.java
+++ b/common/src/main/java/com/team/common/ApiResponse.java
@@ -1,4 +1,4 @@
-package com.team.notificationservice.presentation.common;
+package com.team.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;

--- a/common/src/main/java/com/team/common/Constants.java
+++ b/common/src/main/java/com/team/common/Constants.java
@@ -1,4 +1,4 @@
-package com.team.notificationservice.presentation.common;
+package com.team.common;
 
 import java.util.UUID;
 

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationSaver.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationSaver.java
@@ -1,9 +1,9 @@
 package com.team.notificationservice.application;
 
+import com.team.common.Constants;
 import com.team.notificationservice.domain.Notification;
 import com.team.notificationservice.domain.NotificationRepository;
 import com.team.notificationservice.domain.SendStatus;
-import com.team.notificationservice.presentation.common.Constants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -1,10 +1,10 @@
 package com.team.notificationservice.application;
 
+import com.team.common.Constants;
 import com.team.notificationservice.domain.Notification;
 import com.team.notificationservice.domain.NotificationRepository;
 import com.team.notificationservice.infrastructure.SlackClient;
 import com.team.notificationservice.presentation.NotificationResponse;
-import com.team.notificationservice.presentation.common.Constants;
 import com.team.notificationservice.presentation.common.ErrorCode;
 import com.team.notificationservice.presentation.common.ServiceException;
 import lombok.RequiredArgsConstructor;

--- a/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
+++ b/notification-service/src/main/java/com/team/notificationservice/application/NotificationService.java
@@ -34,9 +34,9 @@ public class NotificationService {
         String targetSlackId = resolveTargetSlackId(dto);
 
         // 2. 수신자 UUID 결정
-        UUID receiverUuid = null;
+        UUID receiverUuid = parseUserId(userIdFromHeader);
 
-          //TODO 헤더 작업 완료 시 주석 해제
+        //TODO 헤더 작업 완료 시 주석 해제
 //        if (userIdFromHeader != null && !userIdFromHeader.isBlank()) {
 //            try {
 //                receiverUuid = UUID.fromString(userIdFromHeader);
@@ -72,6 +72,16 @@ public class NotificationService {
         return targetSlackId;
     }
 
+    private UUID parseUserId(String userId) {
+        if (userId == null || userId.isBlank()) return null;
+        try {
+            return UUID.fromString(userId);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid UUID format: {}", userId);
+            return null;
+        }
+    }
+
     public Page<NotificationResponse> searchNotifications(NotificationSearchCondition condition, Pageable pageable) {
         Page<Notification> result;
 
@@ -99,19 +109,20 @@ public class NotificationService {
             .orElseThrow(() -> new ServiceException(ErrorCode.NOTI_NOTIFICATION_NOT_FOUND));
 
         // deletedBy가 null/blank/SYSTEM인 경우 조건문으로 처리하고, 그 외의 경우 try-catch를 통해 UUID 파싱 실패 시 시스템 ID로 대체
-        UUID adminUuid;
-        if (deletedBy == null || deletedBy.isBlank() || Constants.SYSTEM_USER_ID.equals(deletedBy)) {
-            adminUuid = Constants.SYSTEM_UUID;
-        } else {
-            try {
-                adminUuid = UUID.fromString(deletedBy);
-            } catch (IllegalArgumentException e) {
-                log.debug("deletedBy UUID 파싱 실패, 시스템 ID로 대체: {}", deletedBy);
-                adminUuid = Constants.SYSTEM_UUID;
-            }
-        }
-
+        UUID adminUuid = parseAdminId(deletedBy);
         notification.delete(adminUuid);
         notificationRepository.save(notification);
+    }
+
+    private UUID parseAdminId(String deletedBy) {
+        if (deletedBy == null || deletedBy.isBlank() || Constants.SYSTEM_USER_ID.equals(deletedBy)) {
+            return Constants.SYSTEM_UUID;
+        }
+        try {
+            return UUID.fromString(deletedBy);
+        } catch (IllegalArgumentException e) {
+            log.debug("deletedBy UUID 파싱 실패, 시스템 ID로 대체: {}", deletedBy);
+            return Constants.SYSTEM_UUID;
+        }
     }
 }

--- a/notification-service/src/main/java/com/team/notificationservice/infrastructure/config/JpaAuditConfig.java
+++ b/notification-service/src/main/java/com/team/notificationservice/infrastructure/config/JpaAuditConfig.java
@@ -1,6 +1,6 @@
 package com.team.notificationservice.infrastructure.config;
 
-import com.team.notificationservice.presentation.common.Constants;
+import com.team.common.Constants;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -1,11 +1,11 @@
 package com.team.notificationservice.presentation;
 
+import com.team.common.ApiResponse;
 import com.team.common.page.PageResponse;
 import com.team.common.page.PageSizeUtils;
 import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
-import com.team.notificationservice.presentation.common.ApiResponse;
 import com.team.notificationservice.presentation.common.ErrorCode;
 import com.team.notificationservice.presentation.common.ServiceException;
 import jakarta.validation.Valid;
@@ -74,14 +74,22 @@ public class NotificationController {
         @Valid NotificationSearchCondition condition,
         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
+        // 1. common 유틸을 사용한 페이지 사이즈 정규화
         int normalizedSize = PageSizeUtils.normalize(pageable.getPageSize());
+
+        // 2. 클라이언트의 1-기반 페이지를 서버의 0-기반 페이지로 변환
+        int zeroBasedPage = Math.max(pageable.getPageNumber() - 1, 0);
+
+        // 3. 변환된 페이지 번호로 새로운 Pageable 생성
         Pageable normalizedPageable = PageRequest.of(
-            pageable.getPageNumber(),
+            zeroBasedPage,
             normalizedSize,
             pageable.getSort()
         );
 
         Page<NotificationResponse> resultPage = notificationService.searchNotifications(condition, normalizedPageable);
+
+        // 4. PageResponse.from은 내부적으로 다시 +1을 하여 클라이언트에게 1-기반으로 응답함
         return ApiResponse.success(PageResponse.from(resultPage));
     }
 

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -1,5 +1,7 @@
 package com.team.notificationservice.presentation;
 
+import com.team.common.page.PageResponse;
+import com.team.common.page.PageSizeUtils;
 import com.team.notificationservice.application.NotificationRequest;
 import com.team.notificationservice.application.NotificationSearchCondition;
 import com.team.notificationservice.application.NotificationService;
@@ -11,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -67,11 +70,19 @@ public class NotificationController {
     }
 
     @GetMapping("/api/v1/notifications")
-    public ApiResponse<Page<NotificationResponse>> getNotifications(
+    public ApiResponse<PageResponse<NotificationResponse>> getNotifications(
         @Valid NotificationSearchCondition condition,
         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return ApiResponse.success(notificationService.searchNotifications(condition, pageable));
+        int normalizedSize = PageSizeUtils.normalize(pageable.getPageSize());
+        Pageable normalizedPageable = PageRequest.of(
+            pageable.getPageNumber(),
+            normalizedSize,
+            pageable.getSort()
+        );
+
+        Page<NotificationResponse> resultPage = notificationService.searchNotifications(condition, normalizedPageable);
+        return ApiResponse.success(PageResponse.from(resultPage));
     }
 
     @DeleteMapping("/api/v1/notifications/{id}")

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/NotificationExceptionHandler.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/NotificationExceptionHandler.java
@@ -1,8 +1,6 @@
 package com.team.notificationservice.presentation.common;
 
-import com.team.notificationservice.presentation.common.ApiResponse.ValidationError;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.team.common.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -12,6 +10,9 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
@@ -39,7 +40,7 @@ public class NotificationExceptionHandler {
             .collect(Collectors.joining(", "));
         log.warn("ValidationException: {} field error(s) in [{}]", e.getBindingResult().getFieldErrorCount(), fields);
 
-        List<ValidationError> errors = e.getBindingResult()
+        List<ApiResponse.ValidationError> errors = e.getBindingResult()
             .getFieldErrors()
             .stream()
             .map(error -> new ApiResponse.ValidationError(

--- a/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/common/ServiceException.java
@@ -1,5 +1,6 @@
 package com.team.notificationservice.presentation.common;
 
+import com.team.common.ApiResponse;
 import com.team.common.exception.BusinessException;
 import lombok.Getter;
 

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
@@ -203,4 +203,27 @@ class NotificationServiceApplicationTests {
         assertEquals(1, response.content().size());
         assertEquals(1, response.pageInfo().currentPage());
     }
+
+    @Test
+    @DisplayName("컨트롤러의 1-based 페이지가 서비스 요청 시 0-based Pageable로 처리되는지 검증")
+    void verifyPagingConversion() {
+        // given
+        String slackId = "U123";
+        NotificationSearchCondition cond = new NotificationSearchCondition(slackId, null);
+
+        // 컨트롤러에서 page=1 요청 시 생성될 0-based Pageable (pageNumber = 0)
+        Pageable zeroBasedPageable = PageRequest.of(0, 10);
+
+        when(notificationRepository.findByReceiverSlackIdAndDeletedAtIsNull(eq(slackId), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of()));
+
+        // when
+        notificationService.searchNotifications(cond, zeroBasedPageable);
+
+        // then: 리포지토리에 전달된 Pageable의 페이지 번호가 0인지 확인
+        verify(notificationRepository).findByReceiverSlackIdAndDeletedAtIsNull(
+            eq(slackId),
+            argThat(p -> p.getPageNumber() == 0)
+        );
+    }
 }

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationServiceApplicationTests.java
@@ -1,6 +1,10 @@
 package com.team.notificationservice;
 
-import com.team.notificationservice.application.*;
+import com.team.common.page.PageResponse;
+import com.team.notificationservice.application.NotificationRequest;
+import com.team.notificationservice.application.NotificationSaver;
+import com.team.notificationservice.application.NotificationSearchCondition;
+import com.team.notificationservice.application.NotificationService;
 import com.team.notificationservice.domain.MsgType;
 import com.team.notificationservice.domain.Notification;
 import com.team.notificationservice.domain.NotificationRepository;
@@ -183,5 +187,20 @@ class NotificationServiceApplicationTests {
 
         // then: 0000... 시스템 ID 확인
         assertEquals(UUID.fromString("00000000-0000-0000-0000-000000000000"), mockNoti.getDeletedBy());
+    }
+
+    @Test
+    @DisplayName("common 규격 PageResponse 변환 검증")
+    void checkPageResponseMapping() {
+        // given
+        Notification mockNoti = Notification.builder().msgContent("테스트").receiverSlackId("U1").build();
+        Page<NotificationResponse> resultPage = new PageImpl<>(List.of(NotificationResponse.from(mockNoti)), PageRequest.of(0, 10), 1);
+
+        // when
+        PageResponse<NotificationResponse> response = PageResponse.from(resultPage);
+
+        // then
+        assertEquals(1, response.content().size());
+        assertEquals(1, response.pageInfo().currentPage());
     }
 }

--- a/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/presentation/NotificationControllerRestDocsTest.java
@@ -140,7 +140,7 @@ class NotificationControllerRestDocsTest {
         mockMvc.perform(get("/api/v1/notifications")
                 .param("slackId", "U12345678")
                 .param("keyword", "배송")
-                .param("page", "0")
+                .param("page", "1")
                 .param("size", "10"))
             .andExpect(status().isOk())
             .andDo(document("notifications/list",
@@ -148,7 +148,7 @@ class NotificationControllerRestDocsTest {
                 queryParameters(
                     parameterWithName("slackId").description("수신자 슬랙 ID"),
                     parameterWithName("keyword").description("메시지 본문 검색 키워드").optional(),
-                    parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+                    parameterWithName("page").description("페이지 번호 (1부터 시작)").optional(),
                     parameterWithName("size").description("페이지당 항목 수").optional()
                 ),
                 // responseFields 대신 relaxedResponseFields 사용
@@ -164,13 +164,10 @@ class NotificationControllerRestDocsTest {
                     fieldWithPath("data.content[].createdAt").description("생성 일시"),
 
                     // 페이징 관련 주요 정보 (필요한 것만 선택 기록)
-                    fieldWithPath("data.totalElements").description("전체 데이터 개수"),
-                    fieldWithPath("data.totalPages").description("전체 페이지 수"),
-                    fieldWithPath("data.size").description("페이지 크기"),
-                    fieldWithPath("data.number").description("현재 페이지 번호"),
-                    fieldWithPath("data.first").description("첫 페이지 여부"),
-                    fieldWithPath("data.last").description("마지막 페이지 여부"),
-                    fieldWithPath("data.empty").description("결과 비어있음 여부")
+                    fieldWithPath("data.pageInfo.currentPage").description("현재 페이지 번호"),
+                    fieldWithPath("data.pageInfo.size").description("페이지당 크기"),
+                    fieldWithPath("data.pageInfo.totalElements").description("전체 데이터 개수"),
+                    fieldWithPath("data.pageInfo.totalPages").description("전체 페이지 수")
 
                     // pageable.sort, pageable.offset 등은 적지 않아도 에러가 나지 않음!
                 )
@@ -269,10 +266,10 @@ class NotificationControllerRestDocsTest {
                     fieldWithPath("code").description("응답 코드"),
                     fieldWithPath("message").description("응답 메시지"),
                     fieldWithPath("data.content").description("빈 결과 리스트"),
-                    fieldWithPath("data.totalElements").description("전체 요소 개수"),
-                    fieldWithPath("data.totalPages").description("전체 페이지 수"),
-                    fieldWithPath("data.number").description("현재 페이지 번호"),
-                    fieldWithPath("data.empty").description("비어있음 여부")
+                    fieldWithPath("data.pageInfo.totalElements").description("전체 요소 개수"),
+                    fieldWithPath("data.pageInfo.totalPages").description("전체 페이지 수"),
+                    fieldWithPath("data.pageInfo.currentPage").description("현재 페이지 번호"),
+                    fieldWithPath("data.pageInfo.size").description("페이지 크기")
                 )
             ));
     }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- common 모듈에서 정의된 공통 페이징 응답 규격(PageResponse)을 notification-service에 도입
- 페이지 사이즈 정규화 유틸리티(PageSizeUtils)를 적용하여 API 안정성을 높였습니다.

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #101 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="429" height="358" alt="스크린샷 2026-04-03 오후 3 12 17" src="https://github.com/user-attachments/assets/1813f334-8822-4d76-825f-dcb3b4ee3217" />
<img width="427" height="360" alt="스크린샷 2026-04-03 오후 3 12 28" src="https://github.com/user-attachments/assets/ee1d7b91-e68b-4021-9c9d-4af6f723bcf8" />
<img width="565" height="693" alt="스크린샷 2026-04-03 오후 3 16 33" src="https://github.com/user-attachments/assets/dc61a15a-b7ad-4ada-b9a8-ebe2221c7dd8" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 알림 목록 조회 API의 페이징 응답 형식이 페이지정보(pageInfo) 구조로 변경되었습니다.
  * 페이지 번호가 1부터 시작하도록 변경되었습니다.
  * 요청한 페이지 크기가 자동 정규화되어 일관된 페이지 크기 처리가 이루어집니다.

* **버그 수정**
  * HTTP 헤더 기반 사용자/관리자 식별 처리 안정성이 향상되어 알림 생성·삭제 동작이 더 일관되게 동작합니다.

* **테스트 / 문서**
  * 페이징 매핑 및 REST 문서가 이에 맞춰 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->