### PR TITLE
chore 117/ user-service _ 로컬 프로필에서 더미데이터 생성

### DIFF
--- a/user-service/src/main/resources/application-local.properties
+++ b/user-service/src/main/resources/application-local.properties
@@ -1,0 +1,1 @@
+spring.flyway.locations=classpath:db/migration,classpath:db/dummy

--- a/user-service/src/main/resources/db/dummy/V100__insert_dummy_data.sql
+++ b/user-service/src/main/resources/db/dummy/V100__insert_dummy_data.sql
@@ -1,0 +1,92 @@
+/* =========================================================
+   [USER-SERVICE] DUMMY DATA (local only)
+   - 비밀번호는 모두 '1234' (BCrypt 인코딩)
+   - hub_id, company_id는 더미 UUID 사용
+   - ON CONFLICT DO NOTHING: 기존 데이터와 충돌 시 스킵
+   ========================================================= */
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =========================================================
+-- p_user
+-- =========================================================
+INSERT INTO p_user (id, login_id, password, name, role, slack_id, email, phone_number,
+                    signup_status, affiliated_status, created_at, created_by)
+VALUES
+    -- MASTER_ADMIN (소속 없음)
+    ('00000000-0000-0000-0000-000000000001',
+     'master_admin',
+     crypt('1234', gen_salt('bf', 10)),
+     '마스터관리자', 'MASTER_ADMIN', 'slack_master', 'master@test.com', '010-0000-0001',
+     'APPROVED', 'NOT_APPLICABLE', NOW(), '00000000-0000-0000-0000-000000000001'),
+
+    -- HUB_ADMIN (허브 소속)
+    ('00000000-0000-0000-0000-000000000002',
+     'hub_admin',
+     crypt('1234', gen_salt('bf', 10)),
+     '허브관리자', 'HUB_ADMIN', 'slack_hub_admin', 'hub_admin@test.com', '010-0000-0002',
+     'APPROVED', 'HUB_AFFILIATED', NOW(), '00000000-0000-0000-0000-000000000001'),
+
+    -- HUB_DELIVERY_MANAGER (허브 소속)
+    ('00000000-0000-0000-0000-000000000003',
+     'hub_delivery',
+     crypt('1234', gen_salt('bf', 10)),
+     '허브배송담당자', 'HUB_DELIVERY_MANAGER', 'slack_hub_delivery', 'hub_delivery@test.com', '010-0000-0003',
+     'APPROVED', 'HUB_AFFILIATED', NOW(), '00000000-0000-0000-0000-000000000001'),
+
+    -- COM_DELIVERY_MANAGER (업체 소속)
+    ('00000000-0000-0000-0000-000000000004',
+     'com_delivery',
+     crypt('1234', gen_salt('bf', 10)),
+     '업체배송담당자', 'COM_DELIVERY_MANAGER', 'slack_com_delivery', 'com_delivery@test.com', '010-0000-0004',
+     'APPROVED', 'COM_AFFILIATED', NOW(), '00000000-0000-0000-0000-000000000001'),
+
+    -- COMPANY_MANAGER (업체 소속)
+    ('00000000-0000-0000-0000-000000000005',
+     'company_manager',
+     crypt('1234', gen_salt('bf', 10)),
+     '업체담당자', 'COMPANY_MANAGER', 'slack_company', 'company@test.com', '010-0000-0005',
+     'APPROVED', 'COM_AFFILIATED', NOW(), '00000000-0000-0000-0000-000000000001'),
+
+    -- NONE (가입 대기, 소속 없음)
+    ('00000000-0000-0000-0000-000000000006',
+     'pending_user',
+     crypt('1234', gen_salt('bf', 10)),
+     '가입대기유저', 'NONE', 'slack_pending', 'pending@test.com', '010-0000-0006',
+     'PENDING', 'NOT_APPLICABLE', NOW(), '00000000-0000-0000-0000-000000000006')
+
+ON CONFLICT DO NOTHING;
+
+-- =========================================================
+-- p_hub_user (HUB_AFFILIATED 유저)
+-- =========================================================
+INSERT INTO p_hub_user (id, user_id, hub_id, created_at, created_by)
+VALUES
+    ('00000000-0000-0001-0000-000000000001',
+     '00000000-0000-0000-0000-000000000002',
+     '11111111-1111-1111-1111-111111111111',
+     NOW(), '00000000-0000-0000-0000-000000000001'),
+
+    ('00000000-0000-0001-0000-000000000002',
+     '00000000-0000-0000-0000-000000000003',
+     '11111111-1111-1111-1111-111111111111',
+     NOW(), '00000000-0000-0000-0000-000000000001')
+
+ON CONFLICT DO NOTHING;
+
+-- =========================================================
+-- p_company_user (COM_AFFILIATED 유저)
+-- =========================================================
+INSERT INTO p_company_user (id, user_id, company_id, created_at, created_by)
+VALUES
+    ('00000000-0000-0002-0000-000000000001',
+     '00000000-0000-0000-0000-000000000004',
+     '22222222-2222-2222-2222-222222222222',
+     NOW(), '00000000-0000-0000-0000-000000000001'),
+
+    ('00000000-0000-0002-0000-000000000002',
+     '00000000-0000-0000-0000-000000000005',
+     '22222222-2222-2222-2222-222222222222',
+     NOW(), '00000000-0000-0000-0000-000000000001')
+
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- local 프로필에서만 더미데이터를 생성하는 설정을 추가합니다

1. application-local.properties 추가
2. db/dummy/flyway파일 추가
   - 파일 이름을 V100 으로 시작하게 하여 제일 마지막에 적용
   - ON CONFLICT DO NOTHING; 설정을 추가하여 충돌 방지

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #117  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1415" height="317" alt="image" src="https://github.com/user-attachments/assets/801b4c06-ec96-487f-8f4a-951dbef707b6" />
<img width="207" height="179" alt="image" src="https://github.com/user-attachments/assets/99c5ac7a-8ca0-4ad1-a6fa-cf4d94d62740" />
<img width="657" height="839" alt="image" src="https://github.com/user-attachments/assets/02f8313e-e45c-4dfa-9feb-59a15a73fbae" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
<img width="1454" height="696" alt="image" src="https://github.com/user-attachments/assets/7ca43c63-409a-4bc7-ae4f-7172c21d5458" />

- 위 방법을 사용하면 기본 application.properties 파일에서 로컬 프로필 설정하지 않아도 자동으로 로컬 프로필로 실행됩니다



> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로컬 개발용 데이터베이스 마이그레이션 위치 구성을 추가하여 로컬 마이그레이션을 인식하도록 했습니다.
  * 개발 및 테스트 목적의 샘플 사용자 데이터 초기화 마이그레이션을 추가하여 로컬 환경에서 미리 채워진 더미 사용자 및 관련 링크 데이터를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->