### PR TITLE
Feat/131 AI 배송 정보 내부 조회 API 추가

### DIFF
--- a/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/dto/response/AiDeliveryResponse.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/dto/response/AiDeliveryResponse.java
@@ -1,0 +1,26 @@
+package com.team.deliveryservice.delivery.application.dto.response;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiDeliveryResponse {
+
+    private UUID orderId;
+
+    private UUID originHubId;
+    private UUID destinationHubId;
+
+    private String originHubName;
+    private String destinationHubName;
+
+    private String originAddress;
+    private String destinationAddress;
+
+    private String productName;
+    private String orderRequestDetails;
+
+    private String receiverSlackId;
+}

--- a/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/service/DeliveryService.java
@@ -5,6 +5,7 @@ import com.team.deliveryservice.delivery.application.dto.request.AssignHubDelive
 import com.team.deliveryservice.delivery.application.dto.request.ChangeDeliveryStatusRequest;
 import com.team.deliveryservice.delivery.application.dto.request.CreateDeliveryRequest;
 import com.team.deliveryservice.delivery.application.dto.request.UpdateDeliveryRequest;
+import com.team.deliveryservice.delivery.application.dto.response.AiDeliveryResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryPageResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryResponse;
 import com.team.deliveryservice.delivery.application.search.DeliverySearchCondition;
@@ -42,4 +43,6 @@ public interface DeliveryService {
     DeliveryResponse cancelDelivery(UUID deliveryId);
 
     void deleteDelivery(UUID deliveryId);
+
+    AiDeliveryResponse getAiDeliveryInfo(UUID deliveryId);
 }

--- a/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/service/DeliveryServiceImpl.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/delivery/application/service/DeliveryServiceImpl.java
@@ -6,6 +6,7 @@ import com.team.deliveryservice.delivery.application.dto.request.AssignHubDelive
 import com.team.deliveryservice.delivery.application.dto.request.ChangeDeliveryStatusRequest;
 import com.team.deliveryservice.delivery.application.dto.request.CreateDeliveryRequest;
 import com.team.deliveryservice.delivery.application.dto.request.UpdateDeliveryRequest;
+import com.team.deliveryservice.delivery.application.dto.response.AiDeliveryResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryPageResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryRouteLogResponse;
@@ -25,8 +26,9 @@ import com.team.deliveryservice.infrastructure.client.HubClient;
 import com.team.deliveryservice.infrastructure.client.OrderClient;
 import com.team.deliveryservice.infrastructure.client.dto.CompanyInternalResponse;
 import com.team.deliveryservice.infrastructure.client.dto.HubExistsResponse;
-import com.team.deliveryservice.infrastructure.client.dto.OrderInternalResponse;
+import com.team.deliveryservice.infrastructure.client.dto.HubInternalResponse;
 import com.team.deliveryservice.infrastructure.client.dto.OptimalRouteResponseWrapper;
+import com.team.deliveryservice.infrastructure.client.dto.OrderInternalResponse;
 import feign.FeignException;
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -286,6 +288,40 @@ public class DeliveryServiceImpl implements DeliveryService {
         routeLogs.forEach(routeLog -> routeLog.softDelete(SYSTEM_ACTOR_ID));
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public AiDeliveryResponse getAiDeliveryInfo(UUID deliveryId) {
+        Delivery delivery = getDeliveryEntity(deliveryId);
+
+        OrderInternalResponse order;
+        try {
+            order = orderClient.getOrder(delivery.getOrderId());
+            if (order == null || order.id() == null) {
+                throw new ServiceException(DeliveryErrorCode.ORDER_NOT_FOUND);
+            }
+        } catch (FeignException.NotFound e) {
+            throw new ServiceException(DeliveryErrorCode.ORDER_NOT_FOUND);
+        } catch (FeignException e) {
+            throw new ServiceException(DeliveryErrorCode.ORDER_SERVICE_UNAVAILABLE);
+        }
+
+        HubInternalResponse originHub = getHubInfo(delivery.getOriginHubId());
+        HubInternalResponse destinationHub = getHubInfo(delivery.getDestinationHubId());
+
+        return AiDeliveryResponse.builder()
+            .orderId(delivery.getOrderId())
+            .originHubId(delivery.getOriginHubId())
+            .destinationHubId(delivery.getDestinationHubId())
+            .originHubName(originHub.name())
+            .destinationHubName(destinationHub.name())
+            .originAddress(originHub.address())
+            .destinationAddress(destinationHub.address())
+            .productName(order.productName())
+            .orderRequestDetails(order.requestNote())
+            .receiverSlackId(delivery.getRecipientSlackId())
+            .build();
+    }
+
     // 삭제되지 않은 배송 조회
     private Delivery getDeliveryEntity(UUID deliveryId) {
         return deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
@@ -453,5 +489,21 @@ public class DeliveryServiceImpl implements DeliveryService {
             cause = cause.getCause();
         }
         return false;
+    }
+
+    private HubInternalResponse getHubInfo(UUID hubId) {
+        try {
+            HubInternalResponse hub = hubClient.getHub(hubId, INTERNAL_REQUEST_HEADER);
+
+            if (hub == null || hub.id() == null) {
+                throw new ServiceException(DeliveryErrorCode.HUB_NOT_FOUND);
+            }
+
+            return hub;
+        } catch (FeignException.NotFound e) {
+            throw new ServiceException(DeliveryErrorCode.HUB_NOT_FOUND);
+        } catch (FeignException e) {
+            throw new ServiceException(DeliveryErrorCode.HUB_SERVICE_UNAVAILABLE);
+        }
     }
 }

--- a/delivery-service/src/main/java/com/team/deliveryservice/delivery/presentation/InternalDeliveryController.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/delivery/presentation/InternalDeliveryController.java
@@ -2,6 +2,7 @@ package com.team.deliveryservice.delivery.presentation;
 
 import com.team.deliveryservice.delivery.application.dto.request.ChangeDeliveryStatusRequest;
 import com.team.deliveryservice.delivery.application.dto.request.CreateDeliveryRequest;
+import com.team.deliveryservice.delivery.application.dto.response.AiDeliveryResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryResponse;
 import com.team.deliveryservice.delivery.application.service.DeliveryService;
 import com.team.deliveryservice.global.common.ApiResponse;
@@ -62,5 +63,14 @@ public class InternalDeliveryController {
     ) {
         deliveryService.deleteDelivery(deliveryId);
         return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+    @GetMapping("/{deliveryId}/ai")
+    public ResponseEntity<ApiResponse<AiDeliveryResponse>> getAiInfo(
+        @PathVariable UUID deliveryId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+            deliveryService.getAiDeliveryInfo(deliveryId)
+        ));
     }
 }

--- a/delivery-service/src/main/java/com/team/deliveryservice/infrastructure/client/HubClient.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/infrastructure/client/HubClient.java
@@ -2,6 +2,7 @@ package com.team.deliveryservice.infrastructure.client;
 
 import com.team.deliveryservice.global.config.FeignRetryConfig;
 import com.team.deliveryservice.infrastructure.client.dto.HubExistsResponse;
+import com.team.deliveryservice.infrastructure.client.dto.HubInternalResponse;
 import com.team.deliveryservice.infrastructure.client.dto.OptimalRouteResponseWrapper;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -18,6 +19,12 @@ public interface HubClient {
 
     @GetMapping("/internal/v1/hubs/{hubId}/exists")
     HubExistsResponse existsHub(
+        @PathVariable UUID hubId,
+        @RequestHeader("X-Internal-Request") String internalHeader
+    );
+
+    @GetMapping("/internal/v1/hubs/{hubId}")
+    HubInternalResponse getHub(
         @PathVariable UUID hubId,
         @RequestHeader("X-Internal-Request") String internalHeader
     );

--- a/delivery-service/src/main/java/com/team/deliveryservice/infrastructure/client/dto/HubInternalResponse.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/infrastructure/client/dto/HubInternalResponse.java
@@ -1,0 +1,10 @@
+package com.team.deliveryservice.infrastructure.client.dto;
+
+import java.util.UUID;
+
+public record HubInternalResponse(
+    UUID id,
+    String name,
+    String address
+) {
+}

--- a/delivery-service/src/main/java/com/team/deliveryservice/infrastructure/client/dto/OrderInternalResponse.java
+++ b/delivery-service/src/main/java/com/team/deliveryservice/infrastructure/client/dto/OrderInternalResponse.java
@@ -1,10 +1,9 @@
 package com.team.deliveryservice.infrastructure.client.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
 import java.util.UUID;
-
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record OrderInternalResponse(
@@ -14,6 +13,8 @@ public record OrderInternalResponse(
     UUID receiverCompanyId,
     UUID deliveryId,
     LocalDateTime deadlineAt,
+    String requestNote,
+    String productName,
     String orderStatus
 ) {
 }

--- a/delivery-service/src/test/java/com/team/deliveryservice/application/delivery/DeliveryServiceImplTest.java
+++ b/delivery-service/src/test/java/com/team/deliveryservice/application/delivery/DeliveryServiceImplTest.java
@@ -10,6 +10,7 @@ import com.team.deliveryservice.delivery.application.dto.request.AssignCompanyDe
 import com.team.deliveryservice.delivery.application.dto.request.AssignHubDeliveryManagerRequest;
 import com.team.deliveryservice.delivery.application.dto.request.ChangeDeliveryStatusRequest;
 import com.team.deliveryservice.delivery.application.dto.request.CreateDeliveryRequest;
+import com.team.deliveryservice.delivery.application.dto.response.AiDeliveryResponse;
 import com.team.deliveryservice.delivery.application.dto.response.DeliveryResponse;
 import com.team.deliveryservice.delivery.application.service.DeliveryServiceImpl;
 import com.team.deliveryservice.delivery.domain.Delivery;
@@ -29,6 +30,7 @@ import com.team.deliveryservice.infrastructure.client.HubClient;
 import com.team.deliveryservice.infrastructure.client.OrderClient;
 import com.team.deliveryservice.infrastructure.client.dto.CompanyInternalResponse;
 import com.team.deliveryservice.infrastructure.client.dto.HubExistsResponse;
+import com.team.deliveryservice.infrastructure.client.dto.HubInternalResponse;
 import com.team.deliveryservice.infrastructure.client.dto.OrderInternalResponse;
 import com.team.deliveryservice.infrastructure.client.dto.OptimalRouteResponseWrapper;
 import feign.FeignException;
@@ -48,7 +50,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DeliveryServiceImplTest {
 
-    private static final UUID SYSTEM_ACTOR_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+    private static final UUID SYSTEM_ACTOR_ID =
+        UUID.fromString("00000000-0000-0000-0000-000000000000");
 
     @Mock
     private DeliveryRepository deliveryRepository;
@@ -269,6 +272,8 @@ class DeliveryServiceImplTest {
                 receiverCompanyId,
                 null,
                 LocalDateTime.of(2026, 4, 1, 18, 0),
+                "배송 전에 확인 연락 부탁드립니다.",
+                "신선 전복 세트",
                 "CONFIRMED"
             ));
 
@@ -303,6 +308,8 @@ class DeliveryServiceImplTest {
                 receiverCompanyId,
                 null,
                 LocalDateTime.of(2026, 4, 1, 18, 0),
+                "배송 전에 확인 연락 부탁드립니다.",
+                "신선 전복 세트",
                 "READY_FOR_DELIVERY"
             ));
 
@@ -337,6 +344,8 @@ class DeliveryServiceImplTest {
                 anotherReceiverCompanyId,
                 null,
                 LocalDateTime.of(2026, 4, 1, 18, 0),
+                "배송 전에 확인 연락 부탁드립니다.",
+                "신선 전복 세트",
                 "READY_FOR_DELIVERY"
             ));
 
@@ -371,6 +380,8 @@ class DeliveryServiceImplTest {
                 receiverCompanyId,
                 deliveryId,
                 LocalDateTime.of(2026, 4, 1, 18, 0),
+                "배송 전에 확인 연락 부탁드립니다.",
+                "신선 전복 세트",
                 "READY_FOR_DELIVERY"
             ));
 
@@ -962,6 +973,164 @@ class DeliveryServiceImplTest {
         assertThat(routeLog.getDeletedBy()).isEqualTo(SYSTEM_ACTOR_ID);
     }
 
+    @Test
+    @DisplayName("AI 배송 정보 조회 성공 - 주문, 허브 정보를 조합해 응답한다")
+    void get_ai_delivery_info_success() {
+        UUID deliveryId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UUID originHubId = UUID.randomUUID();
+        UUID destinationHubId = UUID.randomUUID();
+        UUID receiverCompanyId = UUID.randomUUID();
+
+        Delivery delivery = Delivery.create(
+            orderId,
+            originHubId,
+            destinationHubId,
+            receiverCompanyId,
+            "부산광역시 해운대구 우동",
+            "101호",
+            "홍길동",
+            "U12345678",
+            LocalDateTime.of(2026, 4, 1, 18, 0)
+        );
+
+        given(deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)).willReturn(Optional.of(delivery));
+        given(orderClient.getOrder(orderId))
+            .willReturn(new OrderInternalResponse(
+                orderId,
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                receiverCompanyId,
+                deliveryId,
+                LocalDateTime.of(2026, 4, 1, 18, 0),
+                "선물용이라 반드시 내일 오후 2시 전에는 도착해야 합니다. 안전 배송 부탁드려요.",
+                "신선 전복 세트",
+                "READY_FOR_DELIVERY"
+            ));
+        given(hubClient.getHub(eq(originHubId), any()))
+            .willReturn(new HubInternalResponse(
+                originHubId,
+                "서울 허브",
+                "서울특별시 송파구 송파동"
+            ));
+        given(hubClient.getHub(eq(destinationHubId), any()))
+            .willReturn(new HubInternalResponse(
+                destinationHubId,
+                "부산 허브",
+                "부산광역시 해운대구 우동"
+            ));
+
+        AiDeliveryResponse response = deliveryService.getAiDeliveryInfo(deliveryId);
+
+        assertThat(response.getOrderId()).isEqualTo(orderId);
+        assertThat(response.getOriginHubId()).isEqualTo(originHubId);
+        assertThat(response.getDestinationHubId()).isEqualTo(destinationHubId);
+        assertThat(response.getOriginHubName()).isEqualTo("서울 허브");
+        assertThat(response.getDestinationHubName()).isEqualTo("부산 허브");
+        assertThat(response.getOriginAddress()).isEqualTo("서울특별시 송파구 송파동");
+        assertThat(response.getDestinationAddress()).isEqualTo("부산광역시 해운대구 우동");
+        assertThat(response.getProductName()).isEqualTo("신선 전복 세트");
+        assertThat(response.getOrderRequestDetails())
+            .isEqualTo("선물용이라 반드시 내일 오후 2시 전에는 도착해야 합니다. 안전 배송 부탁드려요.");
+        assertThat(response.getReceiverSlackId()).isEqualTo("U12345678");
+    }
+
+    @Test
+    @DisplayName("AI 배송 정보 조회 실패 - 배송이 없으면 DELIVERY_NOT_FOUND")
+    void get_ai_delivery_info_fail_delivery_not_found() {
+        UUID deliveryId = UUID.randomUUID();
+
+        given(deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> deliveryService.getAiDeliveryInfo(deliveryId))
+            .isInstanceOf(ServiceException.class)
+            .hasMessage(DeliveryErrorCode.DELIVERY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("AI 배송 정보 조회 실패 - 주문이 없으면 ORDER_NOT_FOUND")
+    void get_ai_delivery_info_fail_order_not_found() {
+        UUID deliveryId = UUID.randomUUID();
+        Delivery delivery = createDelivery();
+
+        given(deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)).willReturn(Optional.of(delivery));
+        given(orderClient.getOrder(delivery.getOrderId()))
+            .willThrow(feignNotFoundException());
+
+        assertThatThrownBy(() -> deliveryService.getAiDeliveryInfo(deliveryId))
+            .isInstanceOf(ServiceException.class)
+            .hasMessage(DeliveryErrorCode.ORDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("AI 배송 정보 조회 실패 - 주문 서비스 예외면 ORDER_SERVICE_UNAVAILABLE")
+    void get_ai_delivery_info_fail_order_service_unavailable() {
+        UUID deliveryId = UUID.randomUUID();
+        Delivery delivery = createDelivery();
+
+        given(deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)).willReturn(Optional.of(delivery));
+        given(orderClient.getOrder(delivery.getOrderId()))
+            .willThrow(feignBadRequestException());
+
+        assertThatThrownBy(() -> deliveryService.getAiDeliveryInfo(deliveryId))
+            .isInstanceOf(ServiceException.class)
+            .hasMessage(DeliveryErrorCode.ORDER_SERVICE_UNAVAILABLE.getMessage());
+    }
+
+    @Test
+    @DisplayName("AI 배송 정보 조회 실패 - 허브가 없으면 HUB_NOT_FOUND")
+    void get_ai_delivery_info_fail_hub_not_found() {
+        UUID deliveryId = UUID.randomUUID();
+        Delivery delivery = createDelivery();
+
+        given(deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)).willReturn(Optional.of(delivery));
+        given(orderClient.getOrder(delivery.getOrderId()))
+            .willReturn(new OrderInternalResponse(
+                delivery.getOrderId(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                delivery.getReceiverCompanyId(),
+                deliveryId,
+                LocalDateTime.of(2026, 4, 1, 18, 0),
+                "요청사항",
+                "신선 전복 세트",
+                "READY_FOR_DELIVERY"
+            ));
+        given(hubClient.getHub(eq(delivery.getOriginHubId()), any()))
+            .willThrow(feignNotFoundException());
+
+        assertThatThrownBy(() -> deliveryService.getAiDeliveryInfo(deliveryId))
+            .isInstanceOf(ServiceException.class)
+            .hasMessage(DeliveryErrorCode.HUB_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("AI 배송 정보 조회 실패 - 허브 서비스 예외면 HUB_SERVICE_UNAVAILABLE")
+    void get_ai_delivery_info_fail_hub_service_unavailable() {
+        UUID deliveryId = UUID.randomUUID();
+        Delivery delivery = createDelivery();
+
+        given(deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)).willReturn(Optional.of(delivery));
+        given(orderClient.getOrder(delivery.getOrderId()))
+            .willReturn(new OrderInternalResponse(
+                delivery.getOrderId(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                delivery.getReceiverCompanyId(),
+                deliveryId,
+                LocalDateTime.of(2026, 4, 1, 18, 0),
+                "요청사항",
+                "신선 전복 세트",
+                "READY_FOR_DELIVERY"
+            ));
+        given(hubClient.getHub(eq(delivery.getOriginHubId()), any()))
+            .willThrow(feignBadRequestException());
+
+        assertThatThrownBy(() -> deliveryService.getAiDeliveryInfo(deliveryId))
+            .isInstanceOf(ServiceException.class)
+            .hasMessage(DeliveryErrorCode.HUB_SERVICE_UNAVAILABLE.getMessage());
+    }
+
     private Delivery createDelivery() {
         return Delivery.create(
             UUID.randomUUID(),
@@ -1045,6 +1214,8 @@ class DeliveryServiceImplTest {
             receiverCompanyId,
             null,
             LocalDateTime.of(2026, 4, 1, 18, 0),
+            "배송 전에 확인 연락 부탁드립니다.",
+            "신선 전복 세트",
             "READY_FOR_DELIVERY"
         );
     }
@@ -1077,6 +1248,25 @@ class DeliveryServiceImplTest {
             feign.Response.builder()
                 .status(400)
                 .reason("Bad Request")
+                .request(feign.Request.create(
+                    feign.Request.HttpMethod.GET,
+                    "http://localhost/test",
+                    java.util.Map.of(),
+                    null,
+                    StandardCharsets.UTF_8,
+                    null
+                ))
+                .headers(java.util.Map.of())
+                .build()
+        );
+    }
+
+    private FeignException feignNotFoundException() {
+        return FeignException.errorStatus(
+            "test",
+            feign.Response.builder()
+                .status(404)
+                .reason("Not Found")
                 .request(feign.Request.create(
                     feign.Request.HttpMethod.GET,
                     "http://localhost/test",

--- a/hub-server/src/main/java/com/team/hubservice/hub/application/HubService.java
+++ b/hub-server/src/main/java/com/team/hubservice/hub/application/HubService.java
@@ -29,10 +29,10 @@ public class HubService {
         }
 
         Hub hub = Hub.create(
-                command.name(),
-                command.address(),
-                command.latitude(),
-                command.longitude()
+            command.name(),
+            command.address(),
+            command.latitude(),
+            command.longitude()
         );
 
         return HubResult.from(hubRepository.save(hub));
@@ -47,6 +47,10 @@ public class HubService {
 
     @Cacheable(value = "hubs", key = "#hubId")
     public HubResult getHub(UUID hubId) {
+        return HubResult.from(findHubById(hubId));
+    }
+
+    public HubResult getHubInternal(UUID hubId) {
         return HubResult.from(findHubById(hubId));
     }
 
@@ -72,7 +76,7 @@ public class HubService {
 
     private Hub findHubById(UUID hubId) {
         return hubRepository.findById(hubId)
-                .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
     }
 
     private void checkActiveRoutesAndCompanies(UUID hubId) {

--- a/hub-server/src/main/java/com/team/hubservice/hub/presentation/HubInternalController.java
+++ b/hub-server/src/main/java/com/team/hubservice/hub/presentation/HubInternalController.java
@@ -1,13 +1,17 @@
 package com.team.hubservice.hub.presentation;
 
 import com.team.hubservice.hub.application.HubService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
+import com.team.hubservice.hub.presentation.dto.HubInternalResponse;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/internal/v1/hubs")
@@ -22,8 +26,8 @@ public class HubInternalController {
     @GetMapping("/{hubId}/exists")
     public ResponseEntity<Map<String, Object>> checkHubExists(
         @PathVariable UUID hubId,
-        @RequestHeader(value = "X-Internal-Request", required = true) String internalHeader) {
-
+        @RequestHeader(value = "X-Internal-Request", required = true) String internalHeader
+    ) {
         if (!"true".equals(internalHeader)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -43,7 +47,6 @@ public class HubInternalController {
         return ResponseEntity.ok(response);
     }
 
-    // 임시
     @GetMapping("/{hubId}/exists/v2")
     public ResponseEntity<Void> checkHubExistsV2(@PathVariable UUID hubId) {
         boolean exists = hubService.checkHubExists(hubId);
@@ -51,5 +54,23 @@ public class HubInternalController {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{hubId}")
+    public ResponseEntity<HubInternalResponse> getHubInternal(
+        @PathVariable UUID hubId,
+        @RequestHeader(value = "X-Internal-Request", required = true) String internalHeader
+    ) {
+        if (!"true".equals(internalHeader)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        var hub = hubService.getHubInternal(hubId);
+
+        return ResponseEntity.ok(new HubInternalResponse(
+            hub.id(),
+            hub.name(),
+            hub.address()
+        ));
     }
 }

--- a/hub-server/src/main/java/com/team/hubservice/hub/presentation/dto/HubInternalResponse.java
+++ b/hub-server/src/main/java/com/team/hubservice/hub/presentation/dto/HubInternalResponse.java
@@ -1,0 +1,10 @@
+package com.team.hubservice.hub.presentation.dto;
+
+import java.util.UUID;
+
+public record HubInternalResponse(
+    UUID id,
+    String name,
+    String address
+) {
+}


### PR DESCRIPTION
- delivery-service에 AI 전용 배송 정보 조회 API 추가
- 주문/허브 정보를 조합하는 AiDeliveryResponse 응답 구성
- hub-service 내부 허브 단건 조회 API 추가
- Feign Client 및 내부 DTO 연동 반영
- DeliveryServiceImpl AI 조회 테스트 추가 및 기존 테스트 DTO 변경 반영

Related to: #131

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
-

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="1382" height="178" alt="스크린샷 2026-04-06 오전 1 22 37" src="https://github.com/user-attachments/assets/9c2ce9df-98dc-4b23-ba0e-33d1d78677fd" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * AI 기반 배송 정보 조회 기능 추가: 주문 ID, 허브 정보, 주소, 상품명 등 배송 관련 종합 정보를 통합 조회할 수 있는 새로운 API 엔드포인트 추가
  * 내부 허브 정보 조회 엔드포인트 추가: 보안 헤더를 통한 인증된 요청으로 허브 상세 정보 제공

* **테스트**
  * 배송 정보 조회 기능에 대한 성공/실패 시나리오 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->