### PR TITLE
146/Fix 내부 API 검증 헤더 제거 

### DIFF
--- a/hub-server/src/main/java/com/team/hubservice/hub/presentation/HubInternalController.java
+++ b/hub-server/src/main/java/com/team/hubservice/hub/presentation/HubInternalController.java
@@ -24,14 +24,7 @@ public class HubInternalController {
     }
 
     @GetMapping("/{hubId}/exists")
-    public ResponseEntity<Map<String, Object>> checkHubExists(
-        @PathVariable UUID hubId,
-        @RequestHeader(value = "X-Internal-Request", required = true) String internalHeader
-    ) {
-        if (!"true".equals(internalHeader)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-
+    public ResponseEntity<Map<String, Object>> checkHubExists(@PathVariable UUID hubId) {
         boolean isExists = hubService.checkHubExists(hubId);
 
         Map<String, Object> data = new HashMap<>();
@@ -57,14 +50,7 @@ public class HubInternalController {
     }
 
     @GetMapping("/{hubId}")
-    public ResponseEntity<HubInternalResponse> getHubInternal(
-        @PathVariable UUID hubId,
-        @RequestHeader(value = "X-Internal-Request", required = true) String internalHeader
-    ) {
-        if (!"true".equals(internalHeader)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-
+    public ResponseEntity<HubInternalResponse> getHubInternal(@PathVariable UUID hubId) {
         var hub = hubService.getHubInternal(hubId);
 
         return ResponseEntity.ok(new HubInternalResponse(

--- a/hub-server/src/main/java/com/team/hubservice/hubroute/presentation/HubRouteInternalController.java
+++ b/hub-server/src/main/java/com/team/hubservice/hubroute/presentation/HubRouteInternalController.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,16 +28,10 @@ public class HubRouteInternalController {
         this.hubRouteAiService = hubRouteAiService;
     }
 
-    // 기존 optimal 경로 메서드 유지
     @GetMapping("/optimal")
     public ResponseEntity<Map<String, Object>> getOptimalRoute(
         @RequestParam UUID departureHubId,
-        @RequestParam UUID arrivalHubId,
-        @RequestHeader(value = "X-Internal-Request", required = true) String internalHeader) {
-
-        if (!"true".equals(internalHeader)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
+        @RequestParam UUID arrivalHubId) {
 
         OptimalRouteQuery query = new OptimalRouteQuery(departureHubId, arrivalHubId);
         OptimalRouteResult result = hubRouteOptimalService.findOptimalRoute(query);
@@ -55,12 +48,7 @@ public class HubRouteInternalController {
     @GetMapping
     public ResponseEntity<Map<String, Object>> getRouteForAi(
         @RequestParam UUID originId,
-        @RequestParam UUID destinationId,
-        @RequestHeader(value = "X-Internal-Request", required = true) String internalHeader) {
-
-        if (!"true".equals(internalHeader)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
+        @RequestParam UUID destinationId) {
 
         AiRouteResponse response = hubRouteAiService.getRouteInfoForAi(originId, destinationId);
 

--- a/hub-server/src/test/java/com/team/hubservice/hubroute/api/HubRouteInternalControllerRestDocsTest.java
+++ b/hub-server/src/test/java/com/team/hubservice/hubroute/api/HubRouteInternalControllerRestDocsTest.java
@@ -73,15 +73,11 @@ class HubRouteInternalControllerRestDocsTest {
         Mockito.when(hubRouteOptimalService.findOptimalRoute(any(OptimalRouteQuery.class))).thenReturn(result);
 
         mockMvc.perform(get("/internal/v1/hub-route/optimal")
-                .header("X-Internal-Request", "true")
                 .param("departureHubId", departureHubId.toString())
                 .param("arrivalHubId", arrivalHubId.toString())
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andDo(document("hub-route-optimal-get",
-                requestHeaders(
-                    headerWithName("X-Internal-Request").description("내부망 접근 확인 헤더 (반드시 true여야 함)")
-                ),
                 queryParameters(
                     parameterWithName("departureHubId").description("출발 허브 ID"),
                     parameterWithName("arrivalHubId").description("도착 허브 ID")
@@ -117,15 +113,11 @@ class HubRouteInternalControllerRestDocsTest {
             .thenReturn(aiResponse);
 
         mockMvc.perform(get("/internal/v1/hub-route")
-                .header("X-Internal-Request", "true")
                 .param("originId", originId.toString())
                 .param("destinationId", destinationId.toString())
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andDo(document("hub-route-ai-get",
-                requestHeaders(
-                    headerWithName("X-Internal-Request").description("내부망 접근 확인 헤더 (반드시 true여야 함)")
-                ),
                 queryParameters(
                     parameterWithName("originId").description("출발 허브 ID"),
                     parameterWithName("destinationId").description("도착 허브 ID")


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 타 마이크로서비스에서 내부 API 호출 시 발생하는 권한 에러를 해결 
- 인터널 컨트롤러의 필수 헤더 요구사항을 제거함 
- 시큐리티 필터에서 내부망 호출이 권한 검증 없이 통과될 수 있도록 예외 처리를 보장함

<br>

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #146

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="664" height="280" alt="image" src="https://github.com/user-attachments/assets/3e2d5d1b-deab-41d5-a468-1eb49b7a5933" />
<img width="690" height="339" alt="image" src="https://github.com/user-attachments/assets/26256944-ba80-4107-862a-b16e2c430c46" />

<img width="427" height="67" alt="image" src="https://github.com/user-attachments/assets/61dedb4c-0024-494e-8aee-b1051fb66a7d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * 내부 요청 헤더 검증 로직 제거로 API 호출 단순화
  * Hub 존재 확인 및 조회 엔드포인트 개선
  * 경로 최적화 및 AI 경로 정보 조회 엔드포인트 개선

* **Tests**
  * API 테스트 문서 및 요청 헤더 사양 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->