### PR TITLE
Chore/166 hub 도메인 공통 환경변수 분리

### DIFF
--- a/hub-server/src/main/resources/application.properties
+++ b/hub-server/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.config.import=optional:classpath:application-common.properties,optional:classpath:application-secret.properties
+spring.config.import=optional:file:./application-secret.properties,optional:file:../application-secret.properties,optional:classpath:application-secret.properties
 
 server.port=8090
 spring.application.name=hub-service
@@ -23,7 +23,7 @@ eureka.instance.prefer-ip-address=true
 jwt.secret=${JWT_SECRET}
 
 tmap.base-url=https://apis.openapi.sk.com
-tmap.app-key=${TMAP_APP_KEY:}
+tmap.app-key=${TMAP_APP_KEY}
 tmap.use-truck-routes=false
 tmap.request-delay-ms=0
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 중복될 수 있는 시크릿 값을 루트 경로로 분리하여 관리하도록 수정 

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #166

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="2120" height="1228" alt="image" src="https://github.com/user-attachments/assets/1813ae51-55a6-4c5f-8312-d3ba2d9f4da0" />

<img width="716" height="558" alt="image" src="https://github.com/user-attachments/assets/51278545-ff46-4102-8e26-c8045a831bb8" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 애플리케이션 설정 파일 로드 경로가 개선되었습니다. 클래스패스뿐만 아니라 로컬 상대 디렉토리에서도 설정 파일을 로드할 수 있도록 업데이트되었습니다.
  * 애플리케이션 키 관련 필수 설정 속성의 처리 방식이 개선되었습니다. 명시적인 값이 필요하며 기본값 없이 처리되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->