### PR TITLE
fix/186: notification 테스트 코드 일부 수정

### DIFF
--- a/notification-service/src/main/java/com/team/notificationservice/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/team/notificationservice/NotificationServiceApplication.java
@@ -3,12 +3,10 @@ package com.team.notificationservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
 @EnableFeignClients
-@EnableJpaAuditing
 @SpringBootApplication
 public class NotificationServiceApplication {
 

--- a/notification-service/src/main/java/com/team/notificationservice/infrastructure/config/JpaAuditConfig.java
+++ b/notification-service/src/main/java/com/team/notificationservice/infrastructure/config/JpaAuditConfig.java
@@ -8,11 +8,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Slf4j
 @Configuration
+@EnableJpaAuditing
 public class JpaAuditConfig {
     @Bean
     public AuditorAware<UUID> auditorProvider() {

--- a/notification-service/src/test/java/com/team/notificationservice/NotificationControllerSecurityTest.java
+++ b/notification-service/src/test/java/com/team/notificationservice/NotificationControllerSecurityTest.java
@@ -1,99 +1,49 @@
 package com.team.notificationservice;
 
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.spy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.team.notificationservice.domain.Notification;
-import com.team.notificationservice.domain.NotificationRepository;
-import java.util.Optional;
+import com.team.notificationservice.application.NotificationService;
+import com.team.notificationservice.presentation.NotificationController;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(properties = {
-    "spring.config.import=optional:file:../application-common.properties,optional:file:../application-secret.properties"
+@WebMvcTest(NotificationController.class)
+@ImportAutoConfiguration(exclude = {
+    org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class,
+    org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class,
+    SecurityAutoConfiguration.class,
+    SecurityFilterAutoConfiguration.class
 })
-@AutoConfigureMockMvc
 class NotificationControllerSecurityTest {
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockitoBean
-    private NotificationRepository notificationRepository;
-
-    @Test
-    @DisplayName("권한이 없는 유저가 삭제 요청 시 403 에러가 발생한다")
-    void delete_Forbidden_WhenNotMasterAdmin() throws Exception {
-        // given
-        UUID notificationId = UUID.randomUUID();
-
-        // when & then
-        mockMvc.perform(delete("/api/v1/notifications/{id}", notificationId)
-                .header("X-User-Role", "USER") // 잘못된 권한 (MASTER_ADMIN이 아님)
-                .header("X-User-Id", UUID.randomUUID().toString()))
-            .andExpect(status().isForbidden()); // 403 Forbidden 응답 확인
-    }
+    private NotificationService notificationService;
 
     @Test
     @DisplayName("MASTER_ADMIN 권한을 가진 유저가 삭제 요청 시 성공한다")
     void delete_Success_WhenMasterAdmin() throws Exception {
-        // given
         UUID notificationId = UUID.randomUUID();
-        Notification mockNoti = Notification.builder().msgContent("삭제 테스트").build();
 
-        given(notificationRepository.findByIdAndDeletedAtIsNull(notificationId))
-            .willReturn(Optional.of(mockNoti));
-
-        // [추가] save 호출 시의 Stubbing 추가
-        given(notificationRepository.save(any(Notification.class)))
-            .willAnswer(invocation -> invocation.getArgument(0));
-
-        // when & then
-        mockMvc.perform(delete("/api/v1/notifications/{id}", notificationId)
-                .header("X-User-Role", "MASTER_ADMIN")
-                .header("X-User-Id", UUID.randomUUID().toString()))
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("MASTER_ADMIN 권한 삭제 시 실제 DB 반영 여부를 검증한다")
-    void delete_VerifyExecution_WhenMasterAdmin() throws Exception {
-        // given
-        UUID notificationId = UUID.randomUUID();
-        Notification mockNoti = spy(Notification.builder().msgContent("삭제").build());
-
-        given(notificationRepository.findByIdAndDeletedAtIsNull(notificationId))
-            .willReturn(Optional.of(mockNoti));
-        given(notificationRepository.save(any(Notification.class)))
-            .willAnswer(inv -> inv.getArgument(0));
-
-        // when
         mockMvc.perform(delete("/api/v1/notifications/{id}", notificationId)
                 .header("X-User-Role", "MASTER_ADMIN")
                 .header("X-User-Id", UUID.randomUUID().toString()))
             .andExpect(status().isOk());
 
-        // then
-        verify(notificationRepository).save(any());
-        assertNotNull(mockNoti.getDeletedAt());
-    }
-
-    @Test
-    @DisplayName("X-User-Role 헤더가 없으면 401 에러를 반환한다")
-    void delete_Unauthorized_WhenRoleHeaderMissing() throws Exception {
-        mockMvc.perform(delete("/api/v1/notifications/{id}", UUID.randomUUID())
-                .header("X-User-Id", UUID.randomUUID().toString()))
-            .andExpect(status().isUnauthorized());
+        verify(notificationService).deleteNotification(any(UUID.class), anyString());
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- notification의 db 의존적이던 테스트코드 수정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #186   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [x] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * JPA 감사 기능 구성이 개선되었습니다. 내부 아키텍처가 최적화되어 유지보수성이 향상되었습니다.

* **Tests**
  * 알림 컨트롤러 보안 테스트가 개선되었습니다. 테스트 범위 최적화로 더욱 효율적인 검증이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->