### PR TITLE
fix/45: 알림 조회/검색/삭제 권한 MASTER_ADMIN으로 한정

### DIFF
--- a/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/team/notificationservice/presentation/NotificationController.java
@@ -11,7 +11,6 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -32,24 +31,22 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-
-    @Value("${internal.auth.token:}") // application.yml 미설정 시 빈 값 주입
-    private String internalAuthToken;
-
     // 외부용 API (게이트웨이 통과)
     @PostMapping("/api/v1/notifications/slack")
-    public ApiResponse<String> send(@RequestHeader(value = "X-User-Id", required = false) String userId, // 게이트웨이 전달 헤더
+    public ApiResponse<String> send(@RequestHeader(value = "X-User-Id", required = false) String userId,
                                     @RequestBody @Valid NotificationRequest request) {
         notificationService.createAndSend(request, userId);
         return ApiResponse.success("OK");
     }
 
     @GetMapping("/api/v1/notifications/{id}")
+    @RequireRole({"MASTER_ADMIN"})
     public ApiResponse<NotificationResponse> getNotification(@PathVariable UUID id) {
         return ApiResponse.success(notificationService.getNotification(id));
     }
 
     @GetMapping("/api/v1/notifications")
+    @RequireRole({"MASTER_ADMIN"})
     public ApiResponse<PageResponse<NotificationResponse>> getNotifications(
         @Valid NotificationSearchCondition condition,
         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -74,7 +71,7 @@ public class NotificationController {
     }
 
     @DeleteMapping("/api/v1/notifications/{id}")
-    @RequireRole({"MASTER_ADMIN"}) //TODO
+    @RequireRole({"MASTER_ADMIN"})
     public ApiResponse<Void> delete(
         @PathVariable UUID id,
         @RequestHeader(value = "X-User-Id", required = false) String userId) {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 알림 관련 권한 설정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #45 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [x] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 알림 조회 기능에 관리자 권한 요구 사항 추가
  * 특정 알림 상세 조회 및 목록 조회 시 마스터 관리자 역할이 필수

* **개선사항**
  * 불필요한 내부 인증 토큰 제거로 코드 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->